### PR TITLE
Add build path to deployment index

### DIFF
--- a/deployment/image-index.yml
+++ b/deployment/image-index.yml
@@ -1,3 +1,4 @@
 images:
   - name: sawps
     dockerfile: deployment/docker/Dockerfile
+    buildPath: .


### PR DESCRIPTION
Added a build path to the deployment index. This will allow us to build projects with different locations.