### PR TITLE
Map page using base navbar

### DIFF
--- a/django_project/frontend/src/components/Navbar/index.scss
+++ b/django_project/frontend/src/components/Navbar/index.scss
@@ -1,6 +1,7 @@
 .navbar {
     background-color: #282829;
     color: var(--black);
+    box-shadow: none;
 }
 
 .logo-wrapper {

--- a/django_project/frontend/src/containers/MainPage/MainPage.tsx
+++ b/django_project/frontend/src/containers/MainPage/MainPage.tsx
@@ -44,7 +44,7 @@ function MainPage() {
 
   return (
     <div className="App">
-      <ResponsiveNavbar />
+      {/* <ResponsiveNavbar /> */}
       <div className="MainPage">
         <Grid container flexDirection={'row'}>
           <Grid item>

--- a/django_project/frontend/src/containers/MainPage/Map/index.scss
+++ b/django_project/frontend/src/containers/MainPage/Map/index.scss
@@ -1,7 +1,7 @@
 .map-wrap {
     position: relative;
     width: 100%;
-    height: calc(100% - 10px);
+    height: 100%;
 }
 
 .map {

--- a/django_project/frontend/src/containers/MainPage/index.scss
+++ b/django_project/frontend/src/containers/MainPage/index.scss
@@ -1,9 +1,21 @@
+body {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#app {
+    flex: 1;
+    flex-direction: column;
+    display: flex;
+}
+
 .MainPage {
     position: relative;
     display: flex;
     flex-direction: row;
     width: 100%;
-    height: calc(100% - 82px);
+    height: 100%;
 
     .TabHeaders {
         padding-left: 5px;

--- a/django_project/frontend/templates/base.html
+++ b/django_project/frontend/templates/base.html
@@ -26,9 +26,7 @@
 <body>
 {% block header %}
     <!-- Navigation bar -->
-    {% if not skip_nav_bar %}
     {% include 'navibar.html' %}
-    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/django_project/frontend/views/map.py
+++ b/django_project/frontend/views/map.py
@@ -12,5 +12,4 @@ class MapView(TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx['maptiler_api_key'] = settings.MAPTILER_API_KEY
-        ctx['skip_nav_bar'] = True
         return ctx


### PR DESCRIPTION
Map page is now using navbar from django template. I need to set body with flex so the content of the page can grow and not using height calculation.

Preview:

![Screenshot_4596](https://github.com/kartoza/sawps/assets/5819076/9203dd42-33f4-4170-a1e0-4bf58f83f67b)
