### PR TITLE
Fix calculate bbox from SA for tegola

### DIFF
--- a/django_project/frontend/utils/vector_tile.py
+++ b/django_project/frontend/utils/vector_tile.py
@@ -20,7 +20,7 @@ def get_country_bounding_box():
     iso3 = 'ZAF'
     with connection.cursor() as cursor:
         cursor.execute(
-            'SELECT ST_Extent(w.geom) as bextent FROM layer.world w '
+            'SELECT ST_Extent(ST_TRANSFORM(w.geom, 4326)) as bextent FROM layer.world w '
             'WHERE w."ISO_A3"=%s', [iso3]
         )
         extent = cursor.fetchone()


### PR DESCRIPTION
The bbox for SA is calculated from layer.world and its srid was changed at style version 9. This is to fix the bbox calculation when running vector tile generation.