### PR TITLE
Show username and organisation user in the admin panel

### DIFF
--- a/django_project/stakeholder/admin.py
+++ b/django_project/stakeholder/admin.py
@@ -6,5 +6,12 @@ admin.site.register(UserTitle)
 admin.site.register(LoginStatus)
 admin.site.register(UserProfile)
 admin.site.register(Organisation)
-admin.site.register(OrganisationUser)
-admin.site.register(OrganisationRepresentative)
+
+@admin.register(OrganisationUser)
+class OrganisationUserAdmin(admin.ModelAdmin):
+    list_display = ("user", "organisation")
+
+
+@admin.register(OrganisationRepresentative)
+class OrganisationRepresentativeAdmin(admin.ModelAdmin):
+    list_display = ("user", "organisation")

--- a/django_project/stakeholder/models.py
+++ b/django_project/stakeholder/models.py
@@ -114,6 +114,9 @@ class Organisation(models.Model):
         verbose_name_plural = 'Organisations'
         db_table = "organisation"
 
+    def __str__(self):
+        return self.name
+
 
 class OrganisationPersonnel(models.Model):
     """Organisation personnel abstract model."""


### PR DESCRIPTION
1. Added column organisation in the OrganisationUser and in the OrganisationRepresentative with the user and the organisation name.
2. Show username in the User table instead of the object number.
Before
![image](https://github.com/kartoza/sawps/assets/73937490/a0266bde-0706-4269-ba96-77931a19ba9e)
![image](https://github.com/kartoza/sawps/assets/73937490/c7b9b335-8516-49cb-9c83-8080e52fa763)
After
![image](https://github.com/kartoza/sawps/assets/73937490/381e33c6-d983-4dd2-9001-307421efb835)
![image](https://github.com/kartoza/sawps/assets/73937490/d4e35162-7aa0-42ba-a702-4fe427357895)
