### PR TITLE
Fix zoom level on select parcel mode

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
+++ b/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
@@ -5,11 +5,12 @@ import PropertyInterface from "../../../models/Property";
 
 const SEARCH_PARCEL_URL = '/api/map/search/parcel/'
 const SEARCH_PROPERTY_URL = '/api/map/search/property/'
+export const MIN_SELECT_PARCEL_ZOOM_LEVEL = 12
+export const MIN_SELECT_PROPERTY_ZOOM_LEVEL = 12
 const PARCELS_ORIGINAL_ZOOM_LEVELS: any = {
     'erf': 14,
     'holding': 12,
-    'farm_portion': 12,
-    'parent_farm': 10
+    'farm_portion': 12
 }
 
 /**

--- a/django_project/frontend/src/containers/MainPage/Map/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Map/index.tsx
@@ -32,7 +32,9 @@ import {
   findParcelLayer,
   searchParcel,
   searchProperty,
-  getSelectParcelLayerNames
+  getSelectParcelLayerNames,
+  MIN_SELECT_PARCEL_ZOOM_LEVEL,
+  MIN_SELECT_PROPERTY_ZOOM_LEVEL
 } from './MapUtility';
 import PropertyInterface from '../../../models/Property';
 import CustomDrawControl from './CustomDrawControl';
@@ -347,8 +349,10 @@ export default function Map() {
     if (selectionMode === MapSelectionMode.None) return;
     let _parcelLayer = findParcelLayer(contextLayers)
     if (typeof _parcelLayer === 'undefined') return;
+    let _mapZoom = map.current.getZoom()
     if (selectionMode === MapSelectionMode.Parcel) {
-      // TODO: perhaps skip search if not in the parcel zoom?
+      // skip search if not in the parcel zoom
+      if (_mapZoom < MIN_SELECT_PARCEL_ZOOM_LEVEL) return;
       // find parcel
       searchParcel(e.lngLat, selectedProperty.id, (parcel: ParcelInterface) => {
         if (parcel) {
@@ -356,7 +360,8 @@ export default function Map() {
         }
       })
     } else if (selectionMode === MapSelectionMode.Property && uploadMode === UploadMode.None) {
-      // TODO: perhaps skip search if not in the properties zoom?
+      // perhaps skip search if not in the properties zoom?
+      if (_mapZoom < MIN_SELECT_PROPERTY_ZOOM_LEVEL) return;
       // find parcel
       searchProperty(e.lngLat, (property: PropertyInterface) => {
         if (property) {


### PR DESCRIPTION
This is to fix inconsistency by zoom level during select parcel mode. Now, map can display both selected parcels and highlight select parcel mode layer in same zoom level. Also, add checking to search parcel/property only when map is at correct zoom level. cc: @LunaAsefaw 
Preview:

![Peek 2023-07-03 13-13](https://github.com/kartoza/sawps/assets/5819076/4a9c4588-3d74-4393-ac16-76c6a6639484)
