### PR TITLE
Move frontend app build to docker file

### DIFF
--- a/deployment/docker-compose.override.template.yml
+++ b/deployment/docker-compose.override.template.yml
@@ -17,7 +17,6 @@ services:
       dockerfile: deployment/docker/Dockerfile
       target: prod
     volumes:
-      - ../django_project:/home/web/django_project
       - ./volumes/static:/home/web/static
       - ./volumes/media:/home/web/media
 

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -35,6 +35,10 @@ EXPOSE 8080
 
 ADD deployment/docker/uwsgi.conf /uwsgi.conf
 
+# Build front end
+WORKDIR /home/web/django_project/frontend
+RUN npm install --legacy-peer-deps && npm run build
+
 WORKDIR /home/web/django_project
 ENTRYPOINT ["/home/web/django_project/entrypoint.sh"]
 CMD ["uwsgi", "--ini", "/uwsgi.conf"]

--- a/django_project/entrypoint.sh
+++ b/django_project/entrypoint.sh
@@ -8,12 +8,13 @@ echo "-----------------------------------------------------"
 echo "STARTING DJANGO ENTRYPOINT $(date)"
 echo "-----------------------------------------------------"
 
+# 2023-07-04: move to dockerfile build
 # Run NPM
-cd /home/web/django_project/frontend
-echo "Installing FrontEnd libraries..."
-npm install --legacy-peer-deps
-echo "Building FrontEnd..."
-npm run build
+# cd /home/web/django_project/frontend
+# echo "Installing FrontEnd libraries..."
+# npm install --legacy-peer-deps
+# echo "Building FrontEnd..."
+# npm run build
 
 # Run initialization
 cd /home/web/django_project


### PR DESCRIPTION
- Move npm install libraries and npm react build to Dockerfile
- Remove mounting of django_project in docker-compose.override.template.yml because we need to use builds folder inside dockerfile container instead.