### PR TITLE
Filter taxon with rank species only

### DIFF
--- a/django_project/frontend/api_views/population.py
+++ b/django_project/frontend/api_views/population.py
@@ -42,7 +42,9 @@ class PopulationMetadataList(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, *args, **kwargs):
-        taxons = Taxon.objects.all().order_by('scientific_name')
+        taxons = Taxon.objects.filter(
+            taxon_rank__name__iexact="species"
+        ).order_by('scientific_name')
         open_close_systems = OpenCloseSystem.objects.all().order_by('name')
         survey_methods = SurveyMethod.objects.all().order_by('name')
         sampling_size_units = SamplingSizeUnit.objects.all().order_by('unit')


### PR DESCRIPTION
This is for #675. Added filter by taxon_rank = 'species' for pulling species list for dropdown values.