### PR TITLE
Fix sample unit serializer online form

### DIFF
--- a/django_project/frontend/api_views/population.py
+++ b/django_project/frontend/api_views/population.py
@@ -13,7 +13,7 @@ from activity.models import ActivityType
 from activity.serializers import ActivityTypeSerializer
 from occurrence.models import SamplingSizeUnit, SurveyMethod
 from occurrence.serializers import (
-    SamplingSizeUnitSerializer,
+    SamplingSizeUnitMetadataSerializer,
     SurveyMethodSerializer
 )
 from population_data.models import (
@@ -67,7 +67,7 @@ class PopulationMetadataList(APIView):
                     SurveyMethodSerializer(survey_methods, many=True).data
                 ),
                 'sampling_size_units': (
-                    SamplingSizeUnitSerializer(
+                    SamplingSizeUnitMetadataSerializer(
                         sampling_size_units,
                         many=True
                     ).data

--- a/django_project/frontend/src/containers/MainPage/Upload/index.scss
+++ b/django_project/frontend/src/containers/MainPage/Upload/index.scss
@@ -171,6 +171,7 @@
 
                     .ManualForm.MuiButton-root:hover {
                         background: #976534;
+                        color: white;
                     }
 
                     .Download.MuiButton-root {

--- a/django_project/occurrence/serializers.py
+++ b/django_project/occurrence/serializers.py
@@ -34,3 +34,12 @@ class SamplingSizeUnitSerializer(serializers.ModelSerializer):
     class Meta:
         model = SamplingSizeUnit
         fields = '__all__'
+
+
+class SamplingSizeUnitMetadataSerializer(serializers.ModelSerializer):
+    """SamplingSizeUnit Serializer with id and name."""
+    name = serializers.CharField(source='unit')
+
+    class Meta:
+        model = SamplingSizeUnit
+        fields = ['id', 'name']


### PR DESCRIPTION
This is to fix empty list in sample unit dropdown. Related issue: #676.

Also, fix button Online Form on hover:
![2023-07-19_19-11](https://github.com/kartoza/sawps/assets/5819076/28dbad37-17a5-44cc-85ed-7e1bc0eded5b)

cc: @amyburness 