### PR TITLE
Remove django setup from plumber init script

### DIFF
--- a/django_project/plumber_initialize.py
+++ b/django_project/plumber_initialize.py
@@ -12,9 +12,6 @@ This script initializes
 from django.db import connection
 from django.db.utils import OperationalError
 import time
-import django
-
-django.setup()
 
 #########################################################
 # 1. Waiting for PostgreSQL


### PR DESCRIPTION
Removing django_setup since it is not needed and causing permission issue during plumber initialization.