### PR TITLE
patch: resolve key error

### DIFF
--- a/django_project/frontend/views/base_view.py
+++ b/django_project/frontend/views/base_view.py
@@ -24,7 +24,6 @@ def get_user_notifications(request):
     current_date = datetime.now().date()
     reminders = Reminders.objects.filter(
         user=request.user,
-        organisation=request.session[CURRENT_ORGANISATION_ID_KEY],
         status=Reminders.PASSED,
         email_sent=True,
         date__date=current_date


### PR DESCRIPTION
key error was a result of users who dont have an organisation or not having an organisation under selection thus the request object did not have the key error . to resolve the issue I have observed it is not neccessary to filter notifications by organisation as the notifcations are filtered by user and users without organisation can still get notifications for the reminders they set for themselves.