### PR TITLE
patch: prevent noneType object has not attribute 'name'

### DIFF
--- a/django_project/frontend/api_views/statistical.py
+++ b/django_project/frontend/api_views/statistical.py
@@ -57,7 +57,7 @@ class SpeciesNationalTrend(APIView):
                 row.year,
                 row.total,
                 row.survey_method.name,
-                row.count_method.name,
+                row.count_method.name if row.count_method else '',
                 'Open' if row.owned_species.property.open else 'Closed',
                 row.owned_species.property.property_type.name,
                 row.owned_species.property.property_size_ha,


### PR DESCRIPTION
 check if row.count_method is not None. If it's not None, access its name