### PR TITLE
change ecosystem type to biome type; show ecosystem type in popup

### DIFF
--- a/deployment/tegola/tegola.conf
+++ b/deployment/tegola/tegola.conf
@@ -131,7 +131,7 @@ max_connections = 50        # The max connections to maintain in the connection 
     id_fieldname = "id"                # geom id field. default is gid
     srid = 3857                         # the srid of table's geo data. Defaults to WebMercator (3857)
     # tablename = "layer.zaf_provinces_small_scale"  sql or table_name are required
-    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id FROM layer.zaf_provinces_small_scale WHERE geom && !BBOX!"
+    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, adm1_en FROM layer.zaf_provinces_small_scale WHERE geom && !BBOX!"
     geometry_type = "polygon"
 
     # Duplicate this section, one per layer...
@@ -211,7 +211,7 @@ max_connections = 50        # The max connections to maintain in the connection 
     id_fieldname = "id"                # geom id field. default is gid
     srid = 3857                         # the srid of table's geo data. Defaults to WebMercator (3857)
     # tablename = "layer.ecosystems_small_scale"  sql or table_name are required
-    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, biome_18 FROM layer.ecosystems_small_scale WHERE geom && !BBOX!"
+    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, name_18, biome_18 FROM layer.ecosystems_small_scale WHERE geom && !BBOX!"
     geometry_type = "polygon"
 
     # Duplicate this section, one per layer...
@@ -221,7 +221,7 @@ max_connections = 50        # The max connections to maintain in the connection 
     id_fieldname = "id"                # geom id field. default is gid
     srid = 3857                         # the srid of table's geo data. Defaults to WebMercator (3857)
     # tablename = "layer.ecosystems_midscale"  sql or table_name are required
-    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, biome_18 FROM layer.ecosystems_midscale WHERE geom && !BBOX!"
+    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, name_18, biome_18 FROM layer.ecosystems_midscale WHERE geom && !BBOX!"
     geometry_type = "polygon"
 
     # Duplicate this section, one per layer...
@@ -231,7 +231,7 @@ max_connections = 50        # The max connections to maintain in the connection 
     id_fieldname = "id"                # geom id field. default is gid
     srid = 3857                         # the srid of table's geo data. Defaults to WebMercator (3857)
     # tablename = "layer.ecosystems"  sql or table_name are required
-    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, biome_18 FROM layer.ecosystems WHERE geom && !BBOX!"
+    sql = "SELECT ST_AsMVTGeom(geom,!BBOX!) AS geom, id, name_18, biome_18 FROM layer.ecosystems WHERE geom && !BBOX!"
     geometry_type = "polygon"
 
     # Duplicate this section, one per layer...

--- a/django_project/fixtures/context_layer.json
+++ b/django_project/fixtures/context_layer.json
@@ -28,7 +28,7 @@
     "model": "frontend.contextlayer",
     "pk": 4,
     "fields": {
-        "name": "Ecosystem type",
+        "name": "Biome type",
         "is_static": true,
         "layer_names": [
             "ecosystems",

--- a/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
+++ b/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
@@ -121,7 +121,7 @@ export const findParcelLayer = (contextLayers: ContextLayerInterface[]): Context
  * @returns 
  */
 export const findAreaLayers = (contextLayers: ContextLayerInterface[]): string[] => {
-    const areaLayers = ['ecosystem type', 'critical biodiversity areas', 'protected areas']
+    const areaLayers = ['biome type', 'critical biodiversity areas', 'protected areas']
     let _layers = contextLayers.reduce((acc, element) => {
         if (element.isSelected && areaLayers.includes(element.name.toLowerCase())) {
             acc.push(...element.layer_names)
@@ -206,7 +206,7 @@ export const searchProperty = (lngLat: maplibregl.LngLat, callback: (parcel: Pro
 }
 
 const FEATURE_NAME_MAPPING:{ [id: string] : string; } = {
-    'ecosystems': 'biome_18',
+    'ecosystems': 'name_18',
     'biodiversity': 'sensfeat',
     'protected': 'site_type',
     'erf': 'cname',

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -86,7 +86,7 @@ function Filter() {
         },
         {
             "id": 5,
-            "name": "Ecosystem type",
+            "name": "Biome type",
             "isSelected": false
         }
     ])


### PR DESCRIPTION
Show correct ecosystem type in the popup, this PR requires devops help:

- restoring layer schema dump to staging database
- update tegola config file

Preview of changes:
Change ecosystem type to biome type in the layers left side panel
![Screenshot_4648](https://github.com/kartoza/sawps/assets/5819076/047b2252-fe9f-4b95-a6de-fd047a219de6)

Show correct ecosystem type in the popup
![Screenshot_4649](https://github.com/kartoza/sawps/assets/5819076/c8168df9-32aa-4e15-a804-0cb88a4862e2)
