### PR TITLE
fix responsiveness charts on landing page

### DIFF
--- a/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/OverviewCardsHolder/index.tsx
+++ b/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/OverviewCardsHolder/index.tsx
@@ -36,15 +36,15 @@ const OverviewCardsHolder:FC<IOverviewCardsHolder> = ()=>{
     useEffect(() => {
         fetchSpeciesList()
     }, [])
-
+    // 6 charts: xl, 3 charts: md, 2 charts: sm, 1 charts: xs
     return(
-        <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}  data-testid='landing-page-overview-cards-holder' className='landing-page-overview-cards-holder-flex'>        
+        <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12, xl: 12 }}  data-testid='landing-page-overview-cards-holder' className='landing-page-overview-cards-holder-flex'>        
             {species.map((species,index)=>{
                 let chartColors = {
                     'line': species.colour,
                     'area': alpha(species.colour, 0.3)
                 }
-                return <Grid item key={index}>
+                return <Grid item xs={4} xl={2} key={index}>
                     <SpeciesCard key={index} species_id={species.id} species_name={species.species_name} pic={species.icon} population={species.total_population.toString()}
                         growth={species.population_growth.toString()} loss={species.population_loss.toString()} chartColors={chartColors} index={index}
                     />

--- a/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/SpeciesChart/styles.scss
+++ b/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/SpeciesChart/styles.scss
@@ -1,6 +1,12 @@
 .species-chart-container{
+    position: relative;
     width:100%;
     height:100%;
+
+    & > canvas {
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 
 .species-chart-skeleton {


### PR DESCRIPTION
This is to fix #887. Charts will be grouped by 6, 3, 2, and 1.
Preview:
![Screenshot_4654](https://github.com/kartoza/sawps/assets/5819076/554486da-3335-4cb6-8171-74967d3f93ba)

![Screenshot_4655](https://github.com/kartoza/sawps/assets/5819076/e6fc4770-d381-45d6-868e-41e5fe3867db)

![Screenshot_4656](https://github.com/kartoza/sawps/assets/5819076/70773e70-3af2-4040-a948-2da3cf9a5689)

![Screenshot_4657](https://github.com/kartoza/sawps/assets/5819076/52069cad-c977-4e68-b83e-ee8ad60d44c9)
