### PR TITLE
Tinashechiraya patch 4

### DIFF
--- a/django_project/frontend/utils/organisation.py
+++ b/django_project/frontend/utils/organisation.py
@@ -9,6 +9,7 @@ CURRENT_ORGANISATION_KEY = 'current_organisation'
 def get_current_organisation_id(user):
     try:
         user_profile = user.user_profile
-        return user_profile.current_organisation.id
+        if user_profile.current_organisation:
+            return user_profile.current_organisation.id
     except UserProfile.DoesNotExist:
         return None

--- a/django_project/frontend/views/base_view.py
+++ b/django_project/frontend/views/base_view.py
@@ -84,6 +84,10 @@ class RegisteredOrganisationBaseView(TemplateView):
             organisation = (
                 Organisation.objects.all().order_by('name').first()
             )
+            if user_profile.current_organization:
+                organisations = organisations.exclude(
+                    id=user_profile.current_organisation.id
+                )
         else:
             organisation_user = OrganisationUser.objects.filter(
                 user=user

--- a/django_project/frontend/views/base_view.py
+++ b/django_project/frontend/views/base_view.py
@@ -84,10 +84,6 @@ class RegisteredOrganisationBaseView(TemplateView):
             organisation = (
                 Organisation.objects.all().order_by('name').first()
             )
-            if user_profile.current_organization:
-                organisations = organisations.exclude(
-                    id=user_profile.current_organisation.id
-                )
         else:
             organisation_user = OrganisationUser.objects.filter(
                 user=user
@@ -113,9 +109,10 @@ class RegisteredOrganisationBaseView(TemplateView):
             organisations = (
                 Organisation.objects.all().order_by('name')
             )
-            organisations = organisations.exclude(
-                id=user_profile.current_organisation.id
-            )
+            if user_profile.current_organisation:
+                organisations = organisations.exclude(
+                    id=user_profile.current_organisation.id
+                )
         else:
             user_organisations = OrganisationUser.objects.filter(
                 user=user

--- a/django_project/sawps/tests/test_activate_account.py
+++ b/django_project/sawps/tests/test_activate_account.py
@@ -1,0 +1,61 @@
+from django.utils.encoding import force_bytes
+from django.test import (
+    TestCase, 
+)
+from django.contrib.auth.models import User
+from stakeholder.models import (
+    UserProfile
+)
+from django.utils.encoding import force_bytes
+from django.urls import reverse
+from django.contrib.messages import get_messages
+from django.utils.http import (
+    urlsafe_base64_encode
+)
+from sawps.email_verification_token import email_verification_token
+
+class ActivateAccountTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpassword'
+        )
+        self.uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+        self.token = email_verification_token.make_token(self.user)
+        
+
+    def test_activate_account_valid(self):
+        url = reverse(
+            'activate',
+            kwargs={'uidb64': self.uidb64, 'token': self.token}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        # Check for a success message
+        messages = [str(msg) for msg in get_messages(response.wsgi_request)]
+        self.assertEqual(
+            'Your account have been confirmed.',
+            messages[0]
+        )
+
+        # Check if a UserProfile is created
+        self.assertTrue(UserProfile.objects.filter(user=self.user).exists())
+
+    def test_activate_account_invalid_user(self):
+        # Test with an invalid user ID
+        uidb64 = urlsafe_base64_encode(force_bytes(5))
+        url = reverse(
+            'activate',
+            kwargs={'uidb64': uidb64, 'token': self.token}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        # Check for a warning message
+        messages = [str(msg) for msg in get_messages(response.wsgi_request)]
+        self.assertEqual(
+            'The confirmation link was invalid,possibly because it has already been used.',
+            messages[0]
+        )

--- a/django_project/sawps/views.py
+++ b/django_project/sawps/views.py
@@ -13,7 +13,8 @@ from core.settings.contrib import SUPPORT_EMAIL
 from stakeholder.models import (
     Organisation,
     OrganisationInvites,
-    OrganisationUser
+    OrganisationUser,
+    UserProfile
 )
 from sawps.email_verification_token import email_verification_token
 from django.template.loader import render_to_string
@@ -39,6 +40,11 @@ class ActivateAccount(View):
         ):
             user.is_active = True
             user.save()
+
+            if not UserProfile.objects.filter(user=user).exists():
+                UserProfile.objects.create(
+                    user=user
+                )
 
             login(
                 request,


### PR DESCRIPTION
![user_profile_error](https://github.com/kartoza/sawps/assets/70011086/668e92c0-9c19-4f78-b102-12ba6afb9b78)
![attribute error](https://github.com/kartoza/sawps/assets/70011086/3a51904a-3d3f-43c1-a3b0-f4cd694bf7ef)

Description:
when user is super user but doesn't have an organisation currently set on the current organisation field of the user profile this attrib error on the screenshot was arising,
when normal user who doesn't have a user profile logs in to the platform ,the user profile does not exist on user was occurring 

To resolve these , when a user activates their account after registration a user profile will be attached to them 
when a super user doesn't have a current organisation set the attrib error will be supressed
