### PR TITLE
patch: use correct value for rows per page #969

### DIFF
--- a/django_project/frontend/views/users.py
+++ b/django_project/frontend/views/users.py
@@ -324,7 +324,7 @@ class OrganisationUsersView(
         users_page = request.GET.get('users_page', 1)
 
         # Get the rows per page value from the query parameters
-        rows_per_page = request.GET.get('users_per_page', 3)
+        rows_per_page = request.GET.get('users_per_page', 5)
 
         paginator = Paginator(organisation_users, rows_per_page)
 


### PR DESCRIPTION

![Screenshot from 2023-09-13 02-52-47](https://github.com/kartoza/sawps/assets/70011086/7e0b8106-2e2d-4601-8410-58d0ff456b1a)


Description 
an incorrect value was set on the number of rows per page this was causing only a single row to appear per page

@LunaAsefaw on the screenshot you provided https://github.com/kartoza/sawps/issues/969 if you notice there is a arrow icon indicating there is another page available if you clicked it then you were going to see the other organisational member ...but I have resolved that minor bug in this pr .
Also note if you're adding a member to an organisation from the admin side make sure you add them to the organisation users and organisation invites models with their joined status set to true ...this way they will appear on this page for whichever organisation you would have added them for.