### PR TITLE
patch: place footer at the bottom of the page on profile page

### DIFF
--- a/django_project/frontend/templates/organisations.html
+++ b/django_project/frontend/templates/organisations.html
@@ -166,7 +166,7 @@
 
                   <div class="form-group mt-3" style="margin-left: 2%;">
                     <small id="data-privacy" class="form-text text-muted">
-                        How would you like your data to be used? See the SANBI data sharing <a href="#">agreement</a>.
+                        How would you like your data to be used?. See the SANBI data sharing <a href="#">agreement</a>.
                         Switching the toggle will be taken as full agreement to the terms of the option chosen
                     </small>
                   </div>
@@ -248,7 +248,7 @@
   
                   <div class="form-group mt-3" style="margin-left: 2%;">
                     <small id="data-privacy" class="form-text text-muted">
-                        How would you like your data to be used? See the SANBI data sharing <a href="#">agreement</a>.
+                        How would you like your data to be used?. See the SANBI data sharing <a href="URL_HERE">agreement</a>.
                         Switching the toggle will be taken as full agreement to the terms of the option chosen
                     </small>
                   </div>

--- a/django_project/frontend/templates/profile.html
+++ b/django_project/frontend/templates/profile.html
@@ -5,7 +5,7 @@
 
 
 {% block content %}
-<section>
+<section style="min-height:var(--min-content-height);">
   <div class="container py-5">
   <div class="row">
     {% include "profile_config_base.html" %}


### PR DESCRIPTION
Description: 

I have positioned the footer correctly on the profile page

[Screencast from 22-09-2023 09:42:37.webm](https://github.com/kartoza/sawps/assets/70011086/d341eced-b0ef-4fea-a32b-02a5925638dd)

I have prevented the data use permissions statement from changing
[Screencast from 22-09-2023 10:17:13.webm](https://github.com/kartoza/sawps/assets/70011086/6ee6e4dc-206a-4bd9-87fd-3145a4e84cc6)

