### PR TITLE
Rename explore tabs

### DIFF
--- a/django_project/frontend/src/containers/MainPage/MainPage.tsx
+++ b/django_project/frontend/src/containers/MainPage/MainPage.tsx
@@ -56,8 +56,8 @@ function MainPage() {
 
   const tabNameToValue: { [key: string]: number } = {
     'map': 0,
-    'data': 1,
-    'metrics': 2,
+    'report': 1,
+    'charts': 2,
     'upload': 3,
   };
 
@@ -72,7 +72,7 @@ function MainPage() {
   }, [location.search]);
   
   useEffect(() => {
-    const tabNames = ['map', 'data', 'metrics', 'upload'];
+    const tabNames = ['map', 'report', 'charts', 'upload'];
     const selectedTabName = tabNames[selectedTab];
     const newPath = `/${selectedTabName}`;
     if (selectedTab !== 0 && selectedTab !== 3) {
@@ -136,7 +136,7 @@ function MainPage() {
                   <Tabs
                     value={selectedTab}
                     onChange={(event: React.SyntheticEvent, newValue: number) => {
-                      const tabNames = ['map', 'data', 'metrics', 'upload'];
+                      const tabNames = ['map', 'report', 'charts', 'upload'];
                       const selectedTabName = tabNames[newValue];
                       setSelectedTab(newValue);
                       if (selectedTabName === 'upload') {
@@ -150,8 +150,8 @@ function MainPage() {
                     aria-label="Main Page Tabs"
                   >
                     <Tab key={0} label={'MAP'} {...a11yProps(0)} />
-                    <Tab key={1} label={'DATA'} {...a11yProps(1)} />
-                    <Tab key={2} label={'METRICS'} {...a11yProps(2)} />
+                    <Tab key={1} label={'REPORT'} {...a11yProps(1)} />
+                    <Tab key={2} label={'CHARTS'} {...a11yProps(2)} />
                   </Tabs>
                 )}
                 <div style={{ flex: 1 }}></div>

--- a/django_project/frontend/tests/test_map_view.py
+++ b/django_project/frontend/tests/test_map_view.py
@@ -20,13 +20,13 @@ class RedirectViewTests(TestCase):
     def setUp(self):
         self.client = Client()
 
-    def test_redirect_to_data(self):
-        response = self.client.get(reverse('data'))
+    def test_redirect_to_report(self):
+        response = self.client.get(reverse('report'))
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response['location'], f"{reverse('map')}?tab=1")
 
-    def test_redirect_to_metrics(self):
-        response = self.client.get(reverse('metrics'))
+    def test_redirect_to_charts(self):
+        response = self.client.get(reverse('charts'))
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response['location'], f"{reverse('map')}?tab=2")
 

--- a/django_project/frontend/urls.py
+++ b/django_project/frontend/urls.py
@@ -66,8 +66,8 @@ from .views.help import HelpView
 from .views.home import HomeView
 from .views.map import (
     MapView,
-    redirect_to_data,
-    redirect_to_metrics,
+    redirect_to_report,
+    redirect_to_charts,
     redirect_to_upload,
     redirect_to_explore
 )
@@ -223,14 +223,14 @@ urlpatterns = [
     ),
     path('map/', MapView.as_view(), name='map'),
     path(
-        'data/',
-        redirect_to_data,
-        name='data'
+        'report/',
+        redirect_to_report,
+        name='report'
     ),
     path(
-        'metrics/',
-        redirect_to_metrics,
-        name='metrics'
+        'charts/',
+        redirect_to_charts,
+        name='charts'
     ),
     path(
         'upload/',

--- a/django_project/frontend/views/map.py
+++ b/django_project/frontend/views/map.py
@@ -5,13 +5,13 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 
-def redirect_to_data(request):
+def redirect_to_report(request):
     tab_number = 1
     redirect_url = f"{reverse('map')}?tab={tab_number}"
     return HttpResponseRedirect(redirect_url)
 
 
-def redirect_to_metrics(request):
+def redirect_to_charts(request):
     tab_number = 2
     redirect_url = f"{reverse('map')}?tab={tab_number}"
     return HttpResponseRedirect(redirect_url)


### PR DESCRIPTION
[Screencast from 22-09-2023 13:30:24.webm](https://github.com/kartoza/sawps/assets/70011086/d39ed6c5-71a3-4f6a-b78e-8d850e1f4dbc)

Description:
Explore pages have been renamed
metrics to charts
data to report