### PR TITLE
User profile improvements

### DIFF
--- a/django_project/frontend/templates/profile.html
+++ b/django_project/frontend/templates/profile.html
@@ -53,7 +53,7 @@
         </form>
       </div>
     </div>
-    
+
   </div>
 
   <script>
@@ -123,12 +123,12 @@
         return
       }
 
-      
+
     }
 
     emailInput.addEventListener("input", handleEmailValidation);
 
-  
+
   </script>
 
   <style>
@@ -156,11 +156,11 @@
       border-color: var(--green);
       box-shadow: 0 0 0 0.25rem rgba(0, 128, 0, 0.25);
     }
-    
+
     /* Style checked switches with green color */
     .custom-switch .custom-control-input:checked ~ .custom-control-label::before {
-      background-color: var(--green); 
-      border-color: var(--green); 
+      background-color: var(--green);
+      border-color: var(--green);
     }
 
     .text-warning-custom {

--- a/django_project/frontend/tests/test_data_table.py
+++ b/django_project/frontend/tests/test_data_table.py
@@ -18,7 +18,6 @@ from stakeholder.factories import (
     organisationUserFactory,
     userRoleTypeFactory,
 )
-from stakeholder.models import UserProfile
 
 
 class OwnedSpeciesTestCase(TestCase):
@@ -47,11 +46,10 @@ class OwnedSpeciesTestCase(TestCase):
         self.role_organisation_manager = userRoleTypeFactory.create(
             name='Organisation manager',
         )
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=self.organisation_1,
-            user_role_type_id=self.role_organisation_manager
-        )
+        user.user_profile.current_organisation = self.organisation_1
+        user.user_profile.user_role_type_id = self.role_organisation_manager
+        user.save()
+
         self.property = PropertyFactory.create(
             organisation=self.organisation_1,
             name='PropertyA'
@@ -173,11 +171,10 @@ class NationalUserTestCase(TestCase):
         self.role_organisation_manager = userRoleTypeFactory.create(
             name="National data consumer",
         )
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=self.organisation_1,
-            user_role_type_id=self.role_organisation_manager
-        )
+        user.user_profile.current_organisation = self.organisation_1
+        user.user_profile.user_role_type_id = self.role_organisation_manager
+        user.save()
+
         self.property = PropertyFactory.create(
             organisation=self.organisation_1,
             name='PropertyA'
@@ -249,11 +246,10 @@ class RegionalUserTestCase(TestCase):
         self.role_organisation_manager = userRoleTypeFactory.create(
             name="Regional data consumer",
         )
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=self.organisation_1,
-            user_role_type_id=self.role_organisation_manager
-        )
+        user.user_profile.current_organisation = self.organisation_1
+        user.user_profile.user_role_type_id = self.role_organisation_manager
+        user.save()
+
         self.property = PropertyFactory.create(
             organisation=self.organisation_1,
             name='PropertyA'
@@ -311,11 +307,10 @@ class DataScientistTestCase(TestCase):
         self.role_organisation_manager = userRoleTypeFactory.create(
             name="Regional data scientist",
         )
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=self.organisation_1,
-            user_role_type_id=self.role_organisation_manager
-        )
+        user.user_profile.current_organisation = self.organisation_1
+        user.user_profile.user_role_type_id = self.role_organisation_manager
+        user.save()
+
         self.property = PropertyFactory.create(
             organisation=self.organisation_1,
             name='PropertyA'

--- a/django_project/frontend/tests/test_map.py
+++ b/django_project/frontend/tests/test_map.py
@@ -84,19 +84,18 @@ class TestMapAPIViews(TestCase):
         session_key = None
         request.session = engine.SessionStore(session_key)
         view = MapStyles.as_view()
-        response = view(request) 
+        response = view(request)
         self.assertEqual(response.status_code, 200)
-    
+
     def test_map_styles_with_theme_value_for_role(self):
         # test with user role as decision maker
         role = userRoleTypeFactory.create(
             id=1,
-            name = 'Decision Maker',
+            name='Decision Maker',
         )
-        UserProfile.objects.create(
-            user=self.user_1,
-            user_role_type_id=role
-        )
+        self.user_1.user_profile.user_role_type_id = role
+        self.user_1.save()
+
         request = self.factory.get(
             reverse('map-style')
         )
@@ -149,10 +148,9 @@ class TestMapAPIViews(TestCase):
         self.assertEqual(response.data['cname'], self.holding_1.cname)
 
     def test_find_property_by_coord(self):
-        UserProfile.objects.create(
-            user=self.user_1,
-            current_organisation=self.organisation_1
-        )
+        self.user_1.user_profile.current_organisation = self.organisation_1
+        self.user_1.save()
+
         # insert property
         property = PropertyFactory.create(
             geometry=self.holding_1.geom,

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -42,10 +42,8 @@ class BaseTestCase(TestCase):
             organisation=self.organisation_1
         )
 
-        UserProfile.objects.create(
-            user=self.user,
-            current_organisation=self.organisation_1
-        )
+        self.user.user_profile.current_organisation = self.organisation_1
+        self.user.save()
 
         self.property = PropertyFactory.create(
             organisation=self.organisation_1, name="PropertyA"

--- a/django_project/frontend/tests/test_notifications.py
+++ b/django_project/frontend/tests/test_notifications.py
@@ -23,14 +23,14 @@ class GetUserNotificationsTestCase(TestCase):
     def setUp(self):
         # Create a test user
         self.user = User.objects.create_user(
-            username='testuser', 
+            username='testuser',
             password='testpassword'
         )
         # Create a test user profile
-        self.user_profile = UserProfile.objects.create(
-            user=self.user,
-            received_notif=False
-        )
+        self.user_profile = self.user.user_profile
+        self.user_profile.received_notif = False
+        self.user.save()
+
         # create organisation
         self.organisation = organisationFactory.create()
         # Create a test reminder
@@ -46,7 +46,7 @@ class GetUserNotificationsTestCase(TestCase):
         # Simulate a request to the view
         request = RequestFactory().get('get_user_notifications')
         request.user = self.user
-        request.session = {CURRENT_ORGANISATION_ID_KEY: self.organisation.pk} 
+        request.session = {CURRENT_ORGANISATION_ID_KEY: self.organisation.pk}
 
         # Add a message storage to the request
         setattr(request, '_messages', FallbackStorage(request))

--- a/django_project/frontend/tests/test_organisations.py
+++ b/django_project/frontend/tests/test_organisations.py
@@ -7,7 +7,6 @@ from stakeholder.models import OrganisationUser, Organisation, UserProfile
 from stakeholder.factories import (
     organisationFactory,
     userRoleTypeFactory,
-    userProfileFactory
 )
 from stakeholder.views import OrganisationAPIView
 from property.factories import (
@@ -108,11 +107,9 @@ class TestOrganisationAPIView(TestCase):
         user_role = userRoleTypeFactory.create(
             name='Regional data scientist'
         )
-        UserProfile.objects.create(
-            user=self.user_1,
-            current_organisation=self.organisation_1,
-            user_role_type_id=user_role
-        )
+        self.user_1.user_profile.current_organisation = self.organisation_1
+        self.user_1.user_profile.user_role_type_id = user_role
+        self.user_1.save()
 
         request = factory.get(
             reverse('organisation')
@@ -133,11 +130,9 @@ class TestOrganisationAPIView(TestCase):
         user_role = userRoleTypeFactory.create(
             name='National data scientist'
         )
-        UserProfile.objects.create(
-            user=self.user_1,
-            current_organisation=self.organisation_2,
-            user_role_type_id=user_role
-        )
+        self.user_1.user_profile.current_organisation = self.organisation_2
+        self.user_1.user_profile.user_role_type_id = user_role
+        self.user_1.save()
 
         request = factory.get(
             reverse('organisation')

--- a/django_project/frontend/tests/test_organisations.py
+++ b/django_project/frontend/tests/test_organisations.py
@@ -33,9 +33,6 @@ class OrganisationsViewTest(TestCase):
             name="test_organisation",
             data_use_permission=self.data_use_permission
         )
-        userProfileFactory.create(
-            user=self.user
-        )
         device = TOTPDevice(
             user=self.user,
             name='device_name'
@@ -81,7 +78,7 @@ class OrganisationsViewTest(TestCase):
                 args=[self.organisation.id]
                 )
             )
-        
+
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, '/')
 
@@ -100,7 +97,7 @@ class TestOrganisationAPIView(TestCase):
         )
         self.organisation_2 = organisationFactory.create(national=True)
 
-        # create user 
+        # create user
         self.user_1 = UserF.create(username='test_1')
         self.user_2 = UserF.create(username='test_2')
 
@@ -128,7 +125,7 @@ class TestOrganisationAPIView(TestCase):
         _organisation = response.data[0]
         self.assertEqual(_organisation['id'], self.organisation_1.id)
         self.assertEqual(_organisation['name'], self.organisation_1.name)
-    
+
     def test_organisation_list_for_national(self):
         """Test organisation for regional user"""
 
@@ -161,9 +158,6 @@ class OrganisationTests(TestCase):
         self.user = User.objects.create_user(
             username='testuser',
             password='testpassword'
-        )
-        userProfileFactory.create(
-            user=self.user
         )
         device = TOTPDevice(
             user=self.user,

--- a/django_project/frontend/tests/test_property.py
+++ b/django_project/frontend/tests/test_property.py
@@ -7,34 +7,14 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.test import Client, TestCase
 from django.urls import reverse
 from core.settings.utils import absolute_path
-from property.models import (
-    PropertyType,
-    Property,
-    Parcel
-)
-from property.factories import (
-    ProvinceFactory,
-    PropertyFactory
-)
-from stakeholder.factories import (
-    organisationFactory,
-    organisationUserFactory,
-    userProfileFactory
-)
-from frontend.models.parcels import (
-    Erf,
-    Holding
-)
 from frontend.models.places import (
     PlaceNameSmallScale,
     PlaceNameMidScale,
     PlaceNameLargerScale,
     PlaceNameLargestScale
 )
-from frontend.tests.model_factories import UserF
 from frontend.api_views.property import (
     CreateNewProperty,
-    PropertyDetail,
     PropertyList,
     PropertyMetadataList,
     UpdatePropertyBoundaries,
@@ -114,10 +94,10 @@ class TestPropertyAPIViews(TestCase):
             format='json'
         )
         # without adding to organisation, should return 403
-        self.user_1.user_profile = userProfileFactory.create(
-            user=self.user_1,
-            current_organisation=self.organisation
-        )
+        self.user_1.user_profile = self.user_1.user_profile
+        self.user_1.user_profile.current_organisation = self.organisation
+        self.user_1.save()
+
         request.user = self.user_1
         view = CreateNewProperty.as_view()
         response = view(request)
@@ -178,10 +158,10 @@ class TestPropertyAPIViews(TestCase):
         request = self.factory.get(
             reverse('property-list')
         )
-        self.user_2.user_profile = userProfileFactory.create(
-            user=self.user_2,
-            current_organisation=self.organisation
-        )
+        self.user_2.user_profile = self.user_2.user_profile
+        self.user_2.user_profile.current_organisation = self.organisation
+        self.user_2.save()
+
         request.user = self.user_2
         view = PropertyList.as_view()
         response = view(request)
@@ -200,10 +180,8 @@ class TestPropertyAPIViews(TestCase):
             password='testpasswordd'
         )
 
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=organisation,
-        )
+        user.user_profile.current_organisation = organisation
+        user.save()
 
         property = PropertyFactory.create(
             organisation=organisation,
@@ -277,10 +255,10 @@ class TestPropertyAPIViews(TestCase):
             reverse('property-create'), data=data,
             format='json'
         )
-        self.user_1.user_profile = userProfileFactory.create(
-            user=self.user_1,
-            current_organisation=self.organisation
-        )
+        self.user_1.user_profile = self.user_1.user_profile
+        self.user_1.user_profile.current_organisation = self.organisation
+        self.user_1.save()
+
         request.user = self.user_1
         organisationUserFactory.create(
             user=self.user_1,
@@ -346,10 +324,10 @@ class TestPropertyAPIViews(TestCase):
         request = self.factory.get(
             reverse('property-search') + f'?search_text=sea'
         )
-        self.user_2.user_profile = userProfileFactory.create(
-            user=self.user_2,
-            current_organisation=self.organisation
-        )
+        self.user_2.user_profile = self.user_2.user_profile
+        self.user_2.user_profile.current_organisation = self.organisation
+        self.user_2.save()
+
         request.user = self.user_2
         view = PropertySearch.as_view()
         response = view(request)

--- a/django_project/frontend/tests/test_users_view.py
+++ b/django_project/frontend/tests/test_users_view.py
@@ -36,14 +36,11 @@ class OrganisationUsersViewTest(TestCase):
         )
         self.role = userRoleTypeFactory.create(
             id=1,
-            name = 'Admin',
+            name='Admin',
         )
-        UserProfile.objects.create(
-            user=self.user,
-            user_role_type_id=self.role,
-            current_organisation=self.organisation
-        )
-
+        self.user.user_profile.user_role_type_id = self.role
+        self.user.user_profile.current_organisation = self.organisation
+        self.user.save()
 
     def test_delete_post_method(self):
         # url = reverse('Users')
@@ -55,14 +52,14 @@ class OrganisationUsersViewTest(TestCase):
                     'current_organisation': self.organisation.name
                 }
         )
-        
+
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content, {'status': 'success'})
 
         # Verify that the OrganisationUser has been deleted
         self.assertFalse(OrganisationUser.objects.filter(
             user=self.organisation_user.user).exists())
-        
+
         # test organisation does not exist
         response = self.client.post(
                 '/users/',
@@ -72,7 +69,7 @@ class OrganisationUsersViewTest(TestCase):
                     'current_organisation': 'fake_org'
                 }
         )
-        
+
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content, {'status': 'failed'})
 
@@ -85,7 +82,7 @@ class OrganisationUsersViewTest(TestCase):
                     'current_organisation': self.organisation.name
                 }
         )
-        
+
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content, {'status': 'failed'})
 
@@ -141,11 +138,10 @@ class OrganisationUsersViewTest(TestCase):
             password='testpassword',
             email='test33@gmail.com'
         )
-        UserProfile.objects.create(
-            user=user,
-            user_role_type_id=self.role,
-            current_organisation=self.organisation
-        )
+        user.user_profile.user_role_type_id = self.role
+        user.user_profile.current_organisation = self.organisation
+        user.save()
+
         OrganisationUser.objects.create(
             organisation=self.organisation, user=user
         )
@@ -173,7 +169,7 @@ class OrganisationUsersViewTest(TestCase):
 
         self.assertIsNotNone(response)
 
-        
+
     def test_search_user_table(self):
         # Create a request object with the required POST data
         response = self.client.post(
@@ -184,7 +180,7 @@ class OrganisationUsersViewTest(TestCase):
                 'current_organisation': self.organisation.name
             }
         )
-                   
+
         # Assert the expected outcome
         expected_data = [
             {
@@ -196,7 +192,7 @@ class OrganisationUsersViewTest(TestCase):
             }
         ]
         expected_json = {'data': json.dumps(expected_data, cls=DjangoJSONEncoder)}
-            
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected_json)
 
@@ -209,7 +205,7 @@ class OrganisationUsersViewTest(TestCase):
                 'current_organisation': self.organisation.name
             }
         )
-                   
+
         # Assert the expected outcome
         expected_data = [
             {
@@ -221,7 +217,7 @@ class OrganisationUsersViewTest(TestCase):
             }
         ]
         expected_json = {'data': json.dumps(expected_data, cls=DjangoJSONEncoder)}
-            
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected_json)
 
@@ -234,11 +230,11 @@ class OrganisationUsersViewTest(TestCase):
                 'current_organisation': 'fake_org'
             }
         )
-                   
+
         # Assert the expected outcome
         expected_data = []
         expected_json = {'data': json.dumps(expected_data, cls=DjangoJSONEncoder)}
-            
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected_json)
 
@@ -270,10 +266,9 @@ class OrganisationUsersViewTest(TestCase):
             password='testpassword',
             email='test2@gmail.com'
         )
-        UserProfile.objects.create(
-            user=user,
-            user_role_type_id=self.role
-        )
+        user.user_profile.user_role_type_id = self.role
+        user.save()
+
         OrganisationUser.objects.create(
             organisation=self.organisation, user=user
         )
@@ -281,8 +276,6 @@ class OrganisationUsersViewTest(TestCase):
         response = view.get_role(user, self.organisation)
 
         self.assertEqual(str(response), 'Admin')
-        
-        
 
     def test_is_new_invitation(self):
         view = OrganisationUsersView()
@@ -325,7 +318,7 @@ class OrganisationUsersViewTest(TestCase):
             email='testadmin@example.com',
             password='testpassword'
         )
-        
+
 
         login = client.login(
             username='testadmin',
@@ -339,8 +332,8 @@ class OrganisationUsersViewTest(TestCase):
             name='device_name'
         )
         device.save()
-        
-        
+
+
         response = client.post('/users/')
 
         # Check if the response status code is OK (200)
@@ -352,4 +345,4 @@ class OrganisationUsersViewTest(TestCase):
         # no organisation users found
         self.assertEqual(context_data, None)
 
-        
+

--- a/django_project/species/test_species_models.py
+++ b/django_project/species/test_species_models.py
@@ -89,10 +89,8 @@ class TaxonTestCase(TestCase):
             password='testpasswordd'
         )
 
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=organisation,
-        )
+        user.user_profile.current_organisation = organisation
+        user.save()
 
         property = PropertyFactory.create(
             organisation=organisation,
@@ -121,10 +119,8 @@ class TaxonTestCase(TestCase):
             password='testpasswordd'
         )
 
-        UserProfile.objects.create(
-            user=user,
-            current_organisation=organisation,
-        )
+        user.user_profile.current_organisation = organisation
+        user.save()
 
         property = PropertyFactory.create(
             organisation=organisation,

--- a/django_project/stakeholder/admin.py
+++ b/django_project/stakeholder/admin.py
@@ -1,22 +1,40 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.models import User
 from stakeholder.models import (
     UserRoleType,
     UserTitle,
     LoginStatus,
-    UserProfile,
     Organisation,
     OrganisationUser,
     OrganisationRepresentative,
     OrganisationInvites,
-    Reminders
+    Reminders,
+    UserProfile
 )
 
 
 admin.site.register(UserRoleType)
 admin.site.register(UserTitle)
 admin.site.register(LoginStatus)
-admin.site.register(UserProfile)
 admin.site.register(Organisation)
+
+
+class UserProfileInline(admin.StackedInline):
+    model = UserProfile
+    can_delete = False
+    verbose_name_plural = 'UserProfile'
+    list_display = (
+        "picture",
+    )
+
+
+class UserAdmin(BaseUserAdmin):
+    inlines = (UserProfileInline, )
+
+
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)
 
 
 @admin.register(OrganisationUser)

--- a/django_project/stakeholder/test_profile.py
+++ b/django_project/stakeholder/test_profile.py
@@ -31,20 +31,26 @@ class TestProfileView(TestCase):
         Tests profile creation
         """
         user = UserF.create()
-        profile = userProfileFactory.create(
-            user=user,
-            picture='profile_pictures/picture_P.jpg',
+
+        self.assertTrue(user.user_profile is not None)
+
+        profile = UserProfile.objects.get(
+            id=user.user_profile.id
         )
 
-        self.assertTrue(profile.user is not None)
-        self.assertEqual(profile.picture, 'profile_pictures/picture_P.jpg')
+        profile.picture = 'profile_pictures/picture_P.jpg'
+        profile.save()
+
+        self.assertEqual(UserProfile.objects.get(
+            id=profile.id
+        ).picture, 'profile_pictures/picture_P.jpg')
 
     def test_profile_update(self):
         """
         Tests profile update
         """
         user = UserF.create()
-        profile = userProfileFactory.create(user=user)
+        profile = user.user_profile
         profile_picture = {
             'picture': 'profile_pictures/picture_P.jpg',
         }
@@ -66,7 +72,7 @@ class TestProfileView(TestCase):
         Tests profile delete
         """
         user = UserF.create()
-        profile = userProfileFactory.create(user=user)
+        profile = user.user_profile
         profile.delete()
 
         self.assertTrue(profile.pk is None)
@@ -160,9 +166,6 @@ class TestProfileView(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_context_data(self):
-        userProfileFactory.create(
-            user=self.test_user
-        )
         device = TOTPDevice(
             user=self.test_user,
             name='device_name'

--- a/django_project/stakeholder/test_tasks.py
+++ b/django_project/stakeholder/test_tasks.py
@@ -36,9 +36,7 @@ class SendReminderEmailsTestCase(TestCase):
             organisation=self.organisation,
             user=self.user
         )
-        self.user_profile = UserProfile.objects.create(
-            user=self.user
-        )
+        self.user_profile = self.user.user_profile
 
         # Create a test reminder
         self.reminder = Reminders.objects.create(

--- a/django_project/stakeholder/test_view.py
+++ b/django_project/stakeholder/test_view.py
@@ -20,7 +20,7 @@ from stakeholder.views import (
 from stakeholder.models import (
     Reminders,
     Organisation,
-    OrganisationUser
+    OrganisationUser, UserProfile
 )
 from django.urls import reverse
 from django.contrib.auth.models import User
@@ -124,10 +124,9 @@ class DeleteReminderAndNotificationTest(TestCase):
             name="test_organisation",
             data_use_permission=self.data_use_permission
         )
-        userProfileFactory.create(
-            user=self.user,
-            current_organisation=self.organisation
-        )
+        self.user.user_profile.current_organisation = self.organisation
+        self.user.save()
+
         self.client = Client()
         self.reminder_1 = Reminders.objects.create(
             user=self.user,
@@ -184,7 +183,6 @@ class DeleteReminderAndNotificationTest(TestCase):
             'csrfmiddlewaretoken': self.client.cookies.get('csrftoken', '')
         }
 
-        
         request = self.factory.post(
             url,
             data=data
@@ -350,10 +348,10 @@ class TestAddReminderAndScheduleTask(TestCase):
             organisation=self.organisation,
             user=self.user
         )
-        userProfileFactory.create(
-            user=self.user,
-            current_organisation=self.organisation
+        self.user.user_profile.current_organisation = (
+            self.organisation
         )
+        self.user.save()
         self.reminder = Reminders.objects.create(
             title='Test Reminder',
             user=self.user,
@@ -445,10 +443,10 @@ class TestRemindersView(TestCase):
             organisation=self.organisation,
             user=self.user
         )
-        userProfileFactory.create(
-            user=self.user,
-            current_organisation=self.organisation
+        self.user.user_profile.current_organisation = (
+            self.organisation
         )
+        self.user.save()
         self.reminder = Reminders.objects.create(
             title='Test Reminder',
             user=self.user,
@@ -489,12 +487,12 @@ class TestRemindersView(TestCase):
             'action': 'get_reminders',
             'csrfmiddlewaretoken': self.client.cookies.get('csrftoken', ''),
         }
-        
+
         request = self.factory.post(
             url,
             data=data
         )
-        
+
         request.user = self.user
         view = RemindersView.as_view()
         response = view(request)
@@ -517,7 +515,7 @@ class TestRemindersView(TestCase):
                 'reminder_type': 'personal',
                 'csrfmiddlewaretoken': self.client.cookies.get('csrftoken', ''),
             }
-        ) 
+        )
 
         request.user = self.user
         view = RemindersView.as_view()
@@ -596,7 +594,7 @@ class TestRemindersView(TestCase):
         self.assertEqual(len(updated_reminders), 2)
         if updated_reminders[1].get('status') == reminder.id:
             self.assertEqual(updated_reminders[1].get('status'),Reminders.DRAFT)
-        
+
         # test with status passed and everyone
         request = self.factory.post(
             url,
@@ -621,7 +619,7 @@ class TestRemindersView(TestCase):
         self.assertEqual(len(updated_reminders), 2)
         if updated_reminders[1].get('status') == reminder.id:
             self.assertEqual(updated_reminders[1].get('status'),Reminders.PASSED)
-        
+
         # test with status active status and fail test
         request = self.factory.post(
             url,
@@ -657,10 +655,10 @@ class SearchRemindersOrNotificationsTest(TestCase):
             name="test_organisation",
             data_use_permission = self.data_use_permission
         )
-        userProfileFactory.create(
-            user=self.user,
-            current_organisation=self.organisation
+        self.user.user_profile.current_organisation = (
+            self.organisation
         )
+        self.user.save()
         self.client = Client()
         self.reminder_1 = Reminders.objects.create(
             user=self.user,
@@ -816,10 +814,10 @@ class GetOrganisationRemindersTest(TestCase):
             name="test_organisation",
             data_use_permission = self.data_use_permission
         )
-        userProfileFactory.create(
-            user=self.user,
-            current_organisation=self.organisation
+        self.user.user_profile.current_organisation = (
+            self.organisation
         )
+        self.user.save()
         self.client = Client()
         self.reminder_1 = Reminders.objects.create(
             user=self.user,
@@ -1030,10 +1028,10 @@ class NotificationsViewTest(TestCase):
             organisation=self.organisation,
             user=self.user
         )
-        userProfileFactory.create(
-            user=self.user,
-            current_organisation=self.organisation
+        self.user.user_profile.current_organisation = (
+            self.organisation
         )
+        self.user.save()
         self.reminder1 = Reminders.objects.create(
             title='Test Reminder 1',
             user=self.user,


### PR DESCRIPTION
Needed for the future user role implementation.

Summary of the changes : 
 - Moved the "UserProfile" admin section to be under "Django Users." This ensures that we don't have two separate "Users" sections in the admin
 - UserProfiles are now automatically created when a User is created. This is achieved using post_save signals, as seen here:
  
 https://github.com/kartoza/sawps/compare/main...dimasciput:sawps:user_profile_improvement?expand=1#diff-c2067d2b677df444591d90f9ddb2bc59d01a009ea635aff491cd8984a324d8b2R168
 
 - Tests have been updated to accommodate these changes
 