### PR TITLE
patch: adjust sidebar contents to take full height

### DIFF
--- a/django_project/frontend/src/containers/MainPage/SideBar/index.scss
+++ b/django_project/frontend/src/containers/MainPage/SideBar/index.scss
@@ -84,7 +84,7 @@
 .sidebarBox {
     padding: 0px 16px;
     width: 100%;
-    max-height: 69vh;
+    max-height: 100%;
     overflow: auto;
     .sidebarBoxHeading {
         display: flex;


### PR DESCRIPTION
[Screencast from 23-09-2023 15:15:48.webm](https://github.com/kartoza/sawps/assets/70011086/7be5e6c5-772a-4294-be01-7c8503b6e593)

Description
I have removed the whitespace at the bottom of the sidebar...now the contents of the sidebar fit the entire height of the sidebar