### PR TITLE
Population estimate rating

### DIFF
--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/ConfidenceRating.tsx
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/ConfidenceRating.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {
+  Modal,
+  Typography,
+  Slider,
+  Paper,
+  Grid,
+  Button,
+} from '@mui/material';
+
+interface ConfidenceRatingProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  currentConfidence: number;
+  onConfidenceChange: (newValue: number) => void;
+  modalHeight?: string;
+}
+
+const ConfidenceRating: React.FC<ConfidenceRatingProps> = ({
+  open,
+  onClose,
+  onSubmit,
+  currentConfidence,
+  onConfidenceChange,
+  modalHeight = 'auto',
+}) => {
+  const handleSliderChange = (event: Event, newValue: number | number[]) => {
+    if (typeof newValue === 'number') {
+      onConfidenceChange(newValue);
+    }
+  };
+
+  const handleValueClick = (value: number) => {
+    onConfidenceChange(value);
+  };
+
+  const renderValues = () => {
+    const values = Array.from({ length: 10 }, (_, index) => index + 1);
+
+    return (
+      <Grid container spacing={2} justifyContent="center">
+        {values.map((value) => (
+          <Grid item key={value}>
+            <Paper
+              sx={{
+                padding: 2,
+                textAlign: 'center',
+                backgroundColor:
+                  value === currentConfidence ? '#f0f0f0' : 'inherit',
+                cursor: 'pointer', // Add cursor style
+              }}
+              onClick={() => handleValueClick(value)}
+            >
+              {value}
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    );
+  };
+
+  return (
+    <Modal open={open} onClose={onSubmit}>
+      <Paper
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: '40%',
+          height: modalHeight,
+          p: 4,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography variant="h6" align="center">
+          Population Estimate Certainty
+        </Typography>
+        <Typography variant="body1" align="left" mt={1}>
+          How confident are you that this estimate is close to the true population size?
+        </Typography>
+        <Typography
+          variant="body2"
+          mt={1}
+          textAlign="center"
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
+          {currentConfidence === 1 && 'Very Unconfident'}
+          {currentConfidence === 10 && 'Very Confident'}
+        </Typography>
+        <Slider
+          value={currentConfidence}
+          onChange={handleSliderChange}
+          min={1}
+          max={10}
+          step={1}
+        />
+        {renderValues()}
+        <Button
+          variant="contained"
+          onClick={onSubmit}
+          sx={{ alignSelf: 'flex-end', mt: 2 }}
+        >
+          Submit
+        </Button>
+      </Paper>
+    </Modal>
+  );
+};
+
+export default ConfidenceRating;

--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/ConfidenceRating.tsx
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/ConfidenceRating.tsx
@@ -90,8 +90,8 @@ const ConfidenceRating: React.FC<ConfidenceRatingProps> = ({
             justifyContent: 'space-between',
           }}
         >
-          {currentConfidence === 1 && 'Very Unconfident'}
-          {currentConfidence === 10 && 'Very Confident'}
+          {currentConfidence === 1 && 'Least confident'}
+          {currentConfidence === 10 && 'Most confident'}
         </Typography>
         <Slider
           value={currentConfidence}

--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
@@ -28,6 +28,7 @@ import {
     OTHER_NUMBER_FIELDS
 } from '../../../models/Upload';
 import { REQUIRED_FIELD_ERROR_MESSAGE } from '../../../utils/Validation';
+import ConfidenceRating from './ConfidenceRating';
 
 interface SpeciesDetailInterface {
     initialData: UploadSpeciesDetailInterface;

--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
@@ -51,6 +51,10 @@ const isOtherSelected = (value: string) => {
 }
 
 export default function SpeciesDetail(props: SpeciesDetailInterface) {
+    const [isConfidenceRatingOpen, setIsConfidenceRatingOpen] = useState(false);
+    const handleOpenConfidenceRating = () => {
+        setIsConfidenceRatingOpen(true);
+    };
     const { 
         initialData, taxonMetadataList, openCloseMetadataList,
         surveyMethodMetadataList, sampling_effort_coverages,
@@ -643,28 +647,52 @@ export default function SpeciesDetail(props: SpeciesDetailInterface) {
                             </Grid>
                             <Grid item className='InputContainer'>
                                 <Grid container flexDirection={'row'} spacing={2}>
+                                    <ConfidenceRating
+                                        open={isConfidenceRatingOpen}
+                                        onClose={() => setIsConfidenceRatingOpen(false)}
+                                        onSubmit={() => setIsConfidenceRatingOpen(false)}
+                                        currentConfidence={data.annual_population.population_estimate_certainty}
+                                        onConfidenceChange={(newValue) =>
+                                            updateAnnualPopulationSelectValue(
+                                            'population_estimate_certainty',
+                                            newValue,
+                                            certainties
+                                            )
+                                        }
+                                        modalHeight="auto"
+                                    />
+
                                     <Grid item xs={6}>
-                                        <FormControl variant="standard" required className='DropdownInput' fullWidth error={validation.annual_population?.population_estimate_certainty}>
-                                            <InputLabel id="population-estimate-certainty-label">Population Estimate Certainty</InputLabel>
-                                            <Select
-                                                labelId="population-estimate-certainty-label"
-                                                id="population-estimate-certainty-select"
-                                                value={data.annual_population.population_estimate_certainty || data.annual_population.population_estimate_certainty == 0 ? data.annual_population.population_estimate_certainty.toString() : ""}
-                                                onChange={(event: SelectChangeEvent) => updateAnnualPopulationSelectValue('population_estimate_certainty', parseInt(event.target.value), certainties)}
-                                                displayEmpty
-                                                label="Population Estimate Certainty"
+                                        <div className="select-container">
+                                            <InputLabel id="population-estimate-certainty-label">
+                                            Population Estimate Certainty*
+                                            </InputLabel>
+                                            <FormControl
+                                            variant="standard"
+                                            required
+                                            className="DropdownInput"
+                                            fullWidth
+                                            error={validation.annual_population?.population_estimate_certainty}
                                             >
-                                                { certainties.map((common: CommonUploadMetadata) => {
-                                                    return (
-                                                        <MenuItem key={common.id} value={common.id}>
-                                                            {common.name}
-                                                        </MenuItem>
-                                                    )
-                                                })                                            
-                                                }
-                                            </Select>
-                                            <FormHelperText>{validation.annual_population?.population_estimate_certainty ? REQUIRED_FIELD_ERROR_MESSAGE : ' '}</FormHelperText>
-                                        </FormControl>
+                                            <div
+                                                className="select-box"
+                                                onClick={handleOpenConfidenceRating}
+                                            >
+                                                {/* Display the selected value or placeholder */}
+                                                <div className="select-value">
+                                                {data.annual_population.population_estimate_certainty ||
+                                                data.annual_population.population_estimate_certainty == 0
+                                                    ? data.annual_population.population_estimate_certainty.toString()
+                                                    : 'Select an option'}
+                                                </div>
+                                            </div>
+                                            <FormHelperText>
+                                                {validation.annual_population?.population_estimate_certainty
+                                                ? REQUIRED_FIELD_ERROR_MESSAGE
+                                                : ' '}
+                                            </FormHelperText>
+                                            </FormControl>
+                                        </div>
                                     </Grid>
                                     <Grid item xs={6}>
                                         <TextField id='certainty_of_bounds' label='Certainty of Bounds' value={data.annual_population.certainty_of_bounds ? data.annual_population.certainty_of_bounds : ''}

--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
@@ -389,7 +389,7 @@ export default function SpeciesDetail(props: SpeciesDetailInterface) {
                                         onChange={(event: SelectChangeEvent) => updateAnnualPopulationSelectValue('sampling_effort_coverage_id', parseInt(event.target.value), sampling_effort_coverages)}
                                         displayEmpty
                                         label="Sampling Effort Coverage"
-                                        style={{ width: '200px' }}
+                                        style={{ width: '300px' }}
                                         >
                                         {sampling_effort_coverages.map((common: CommonUploadMetadata) => {
                                             return (
@@ -412,7 +412,7 @@ export default function SpeciesDetail(props: SpeciesDetailInterface) {
                                         onChange={(event: SelectChangeEvent) => updateAnnualPopulationSelectValue('population_status_id', parseInt(event.target.value), population_statuses)}
                                         displayEmpty
                                         label="Population Status"
-                                        style={{ width: '200px' }}
+                                        style={{ width: '300px' }}
                                         >
                                         {population_statuses.map((common: CommonUploadMetadata) => {
                                             return (
@@ -652,7 +652,7 @@ export default function SpeciesDetail(props: SpeciesDetailInterface) {
                                         onClose={() => setIsConfidenceRatingOpen(false)}
                                         onSubmit={() => setIsConfidenceRatingOpen(false)}
                                         currentConfidence={data.annual_population.population_estimate_certainty}
-                                        onConfidenceChange={(newValue) =>
+                                        onConfidenceChange={(newValue: number) =>
                                             updateAnnualPopulationSelectValue(
                                             'population_estimate_certainty',
                                             newValue,

--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/index.scss
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/index.scss
@@ -138,3 +138,39 @@
         }
     }
 }
+
+
+.select-container {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .select-box {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    cursor: pointer;
+  }
+  
+  .select-value {
+    margin-top: -1px;
+    white-space: nowrap;
+    position: relative;
+  }
+  
+  /* Add an underline */
+  .select-value::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 75%;
+    height: 1px;
+    background-color: gray;
+  }
+  
+  .select-box:hover .select-value {
+    color: inherit;
+    cursor: pointer;
+  }
+  


### PR DESCRIPTION
[Screencast from 23-09-2023 20:49:12.webm](https://github.com/kartoza/sawps/assets/70011086/52b79178-fabb-4917-955e-42e31d2a36c9)

Description:
The population estimate certainty can now be entered using the confidence rating component which displays the confidence levels 
the user can either use the slider to select the confidence level or select a value
and as the user does the slider or the values will reflect those changes
choosing 1 will show text very unconfident whilst 10 will show very confident 

[Screencast from 23-09-2023 21:50:36.webm](https://github.com/kartoza/sawps/assets/70011086/bb7ee20d-6fbf-49f0-8db4-4308f2eeea78)

Description:
I have increased the length of the select boxes so that the dropdown icon doess not overlap text