### PR TITLE
Remove population category from spatial filter

### DIFF
--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -98,12 +98,6 @@ function Filter() {
             "name": "Protected Area",
             "isSelected": false,
             "filterData": ['National Park', 'Heritage sight', 'Nature Reserve']
-        },
-        {
-            "id": 1,
-            "name": "Population Category",
-            "isSelected": false,
-            "filterData": ['0-10', '11-20', '21-50', '50-100', '101-200', '>200']
         }
     ])
 


### PR DESCRIPTION
This PR is for the issue #1129 

Before:- 
![image](https://github.com/kartoza/sawps/assets/138113337/f4fa445b-1f72-430f-9e5a-1a885db3eaad)

After:-
![image](https://github.com/kartoza/sawps/assets/138113337/379b6090-8491-4050-817d-5ef75cdbd5db)
