### PR TITLE
feat: select property ,zoom on map #1128

### DIFF
--- a/django_project/frontend/api_views/data_table.py
+++ b/django_project/frontend/api_views/data_table.py
@@ -17,6 +17,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from species.models import Taxon
+from stakeholder.models import (
+    UserProfile
+)
 
 
 class DataTableAPIView(APIView):

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -44,6 +44,7 @@ const FETCH_AVAILABLE_SPECIES = '/species/'
 const FETCH_PROPERTY_LIST_URL = '/api/property/list/'
 const SEARCH_PROPERTY_URL = '/api/property/search'
 const FETCH_ORGANISATION_LIST_URL = '/api/organisation/'
+const FETCH_PROPERTY_DETAIL_URL = '/api/property/detail/'
 
 interface SearchPropertyResult {
     name: string;
@@ -332,7 +333,7 @@ function Filter() {
         // LEVEL 3 DEBUG
         // console.log('selected properties', updatedSelectedProperty);
       
-        setSelectedPropertyLocal(updatedSelectedProperty);
+        setSelectedProperty(updatedSelectedProperty);
       
         if (updatedSelectedProperty.length === 0) {
             adjustMapToBoundingBox(boundingBox)
@@ -359,24 +360,12 @@ function Filter() {
     // Handle selecting all properties
     const handleSelectAllProperty = () => {
         if (selectedProperty.length === propertyList.length) {
-            setSelectedPropertyLocal([]);
+            setSelectedProperty([]);
             adjustMapToBoundingBox(boundingBox)
         } else {
             const propertyIds = propertyList.map((property) => property.id);
-            setSelectedPropertyLocal(propertyIds);
+            setSelectedProperty(propertyIds);
             zoomToCombinedBoundingBox(propertyIds);
-        }
-    };
-
-
-    const handleSelectedProperty = (id: number) => () => {
-        const propertyExists = selectedProperty.includes(id);
-        if (propertyExists) {
-            const updatedSelectedProperty = selectedProperty.filter((item) => item !== id);
-            setSelectedProperty(updatedSelectedProperty);
-        } else {
-            const updatedSelectedProperty = [...selectedProperty, id];
-            setSelectedProperty(updatedSelectedProperty);
         }
     };
 
@@ -473,13 +462,7 @@ function Filter() {
             setSearchResults([])
         }
     }, [searchInputValue])
-    const handleSelectAllProperty = () => {
-        const propeertyId = propertyList.map(property => property.id)
-        setSelectedProperty(propeertyId)
-        if (selectedProperty.length === propertyList.length) {
-            setSelectedProperty([]);
-        }
-    }
+    
 
     const handleSelectAllOrganisation = () => {
         const organisationId = organisationList.map(data => data.id)

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -76,6 +76,20 @@ function Filter() {
     const [tab, setTab] = useState<string>('')
     const [searchSpeciesList, setSearchSpeciesList] = useState([])
     const [nominatimResults, setNominatimResults] = useState([]);
+    // intial map state vars for zoom out
+    const center = [25.86, -28.52]; // Center point in backend
+    const width = 10;
+    const height = 10;
+
+     // Calculate the bounding box
+    const halfWidth = width / 2;
+    const halfHeight = height / 2;
+    const boundingBox = [
+        center[0] - halfWidth,
+        center[1] - halfHeight,
+        center[0] + halfWidth,
+        center[1] + halfHeight,
+    ];
     
     const handleInputChange = (value: string) => {
         setSearchInputValue(value);
@@ -250,6 +264,110 @@ function Filter() {
         dispatch(setSelectedInfoList(selectedInfo));
     }, [selectedInfo])
 
+    const mergeBoundingBoxes = (boundingBoxes: number[][]): number[] => {
+        let minLeft: number = 180;
+        let minBottom: number = 90;
+        let maxRight: number = -180;
+        let maxTop: number = -90;
+      
+        boundingBoxes.forEach(([left, bottom, right, top]) => {
+          if (left < minLeft) minLeft = left;
+          if (bottom < minBottom) minBottom = bottom;
+          if (right > maxRight) maxRight = right;
+          if (top > maxTop) maxTop = top;
+        });
+      
+        return [minLeft, minBottom, maxRight, maxTop];
+      };
+
+
+    const zoomToCombinedBoundingBox = async (propertyIds: number[]) => {
+        setLoading(true);
+      
+        try {
+          const propertyBoundingBoxes: number[][] = [];
+      
+          // Fetch and collect bounding boxes for each property
+          await Promise.all(
+            propertyIds.map(async (propertyId) => {
+              const response = await axios.get(`${FETCH_PROPERTY_DETAIL_URL}${propertyId}/`);
+              if (response.data && response.data.bbox && response.data.bbox.length === 4) {
+                propertyBoundingBoxes.push(response.data.bbox);
+              }
+            })
+          );
+      
+          if (propertyBoundingBoxes.length > 0) {
+            // Merge the collected bounding boxes
+            const combinedBoundingBox = mergeBoundingBoxes(propertyBoundingBoxes);
+      
+            // LEVEL 1 DEBUG
+            // console.log('navigation to bounding box', combinedBoundingBox);
+
+            adjustMapToBoundingBox(combinedBoundingBox)
+          } else {
+            console.error('No valid bounding boxes found for selected properties.');
+          }
+      
+          setLoading(false);
+        } catch (error) {
+          setLoading(false);
+          console.error(error);
+        }
+      };
+      
+      
+      
+      
+      const handleSelectedProperty = (id: number) => () => {
+        const propertyExists = selectedProperty.includes(id);
+        let updatedSelectedProperty: number[] = [];
+      
+        if (propertyExists) {
+          updatedSelectedProperty = selectedProperty.filter((item) => item !== id);
+        } else {
+          updatedSelectedProperty = [...selectedProperty, id];
+        }
+      
+        // LEVEL 3 DEBUG
+        // console.log('selected properties', updatedSelectedProperty);
+      
+        setSelectedPropertyLocal(updatedSelectedProperty);
+      
+        if (updatedSelectedProperty.length === 0) {
+            adjustMapToBoundingBox(boundingBox)
+        } else {
+          // Call zoomToCombinedBoundingBox with the updated list of selected properties
+          zoomToCombinedBoundingBox(updatedSelectedProperty);
+        }
+      };
+      
+      
+      
+      const adjustMapToBoundingBox = (boundingBox: any[]) => {
+        dispatch(
+            triggerMapEvent({
+                id: uuidv4(),
+                name: MapEvents.PROPERTY_SELECTED,
+                date: Date.now(),
+                payload: boundingBox.map(String),
+            })
+        );
+      };
+      
+
+    // Handle selecting all properties
+    const handleSelectAllProperty = () => {
+        if (selectedProperty.length === propertyList.length) {
+            setSelectedPropertyLocal([]);
+            adjustMapToBoundingBox(boundingBox)
+        } else {
+            const propertyIds = propertyList.map((property) => property.id);
+            setSelectedPropertyLocal(propertyIds);
+            zoomToCombinedBoundingBox(propertyIds);
+        }
+    };
+
 
     const handleSelectedProperty = (id: number) => () => {
         const propertyExists = selectedProperty.includes(id);
@@ -382,71 +500,61 @@ function Filter() {
 
     return (
         <Box>
-            <Box className='searchBar' style={{ marginBottom: '10%' }}>
-                <Box className="sidebarBoxHeading" style={{ display: 'flex', alignItems: 'center' ,marginBottom: '5%'}}>
-                    <SearchIcon
-                        style={{
-                            color: '#70B276',
-                            marginLeft: '15px',
-                        }}
-                    />
-                    <Typography color='#75B37A' fontSize='medium' style={{ marginLeft: '8px' }}>Search address</Typography>
-                </Box>
-                <Autocomplete
-                    disablePortal={false}
-                    id="search-property-autocomplete"
-                    open={searchOpen}
-                    onOpen={() => setSearchOpen(searchInputValue.length > 1)}
-                    onClose={() => setSearchOpen(false)}
-                    options={[
-                        ...searchResults.map((result) => ({
-                          ...result,
-                          key: `searchResult_${result.id}`,
-                        })),
-                        ...nominatimResults.map((result) => ({
-                          ...result,
-                          key: `nominatim_${result.place_id}`,
-                          display_name: result.display_name,
-                        })),
-                      ]}
-                    getOptionLabel={(option) => {
-                        if (option.fclass) {
-                        return `${option.name} (${option.fclass})`;
-                        } else if (option.display_name) {
-                        return option.display_name;
-                        }
-                        return ''; // Return an empty string if neither fclass nor display_name exists
-                    }}
-                    renderInput={(params) => (
-                        <TextField
-                        variant="outlined"
-                        placeholder="Search address"
-                        {...params}
-                        InputProps={{
-                            ...params.InputProps,
-                            endAdornment: (
-                            <InputAdornment position="end">
-                                <SearchIcon />
-                            </InputAdornment>
-                            ),
-                        }}
+            <Box className='sidebarBox'>
+                <Box style={{marginTop: '5%', marginBottom: '10%'}} >
+                    <Box className="sidebarBoxHeading" style={{ display: 'flex', alignItems: 'center' ,marginBottom: '5%'}}>
+                        <SearchIcon
+                            style={{
+                                color: '#70B276',
+                                marginLeft: '15px',
+                            }}
                         />
-                    )}
-                    onChange={(event, newValue) => {
-                        if (newValue && newValue.bbox && newValue.bbox.length === 4) {
-                        // trigger zoom to property
-                        let _bbox = newValue.bbox.map(String);
-                        dispatch(triggerMapEvent({
-                            'id': uuidv4(),
-                            'name': MapEvents.ZOOM_INTO_PROPERTY,
-                            'date': Date.now(),
-                            'payload': _bbox
-                        }));
-                        setSearchInputValue('');
-                        }
-                        else if (newValue && newValue.boundingbox && newValue.boundingbox.length === 4) {
-                            console.log('bounidngbox')
-                            let _bbox = newValue.boundingbox.map(String);
+                        <Typography color='#75B37A' fontSize='medium' style={{ marginLeft: '5px' }}>Search place</Typography>
+                    </Box>
+                    <Autocomplete
+                        disablePortal={false}
+                        id="search-property-autocomplete"
+                        open={searchOpen}
+                        onOpen={() => setSearchOpen(searchInputValue.length > 1)}
+                        onClose={() => setSearchOpen(false)}
+                        options={[
+                            ...searchResults.map((result) => ({
+                            ...result,
+                            key: `searchResult_${result.id}`,
+                            })),
+                            ...nominatimResults.map((result) => ({
+                            ...result,
+                            key: `nominatim_${result.place_id}`,
+                            display_name: result.display_name,
+                            })),
+                        ]}
+                        getOptionLabel={(option) => {
+                            if (option.fclass) {
+                            return `${option.name} (${option.fclass})`;
+                            } else if (option.display_name) {
+                            return option.display_name;
+                            }
+                            return ''; // Return an empty string if neither fclass nor display_name exists
+                        }}
+                        renderInput={(params) => (
+                            <TextField
+                            variant="outlined"
+                            placeholder="Search place"
+                            {...params}
+                            InputProps={{
+                                ...params.InputProps,
+                                endAdornment: (
+                                <InputAdornment position="end">
+                                    <SearchIcon />
+                                </InputAdornment>
+                                ),
+                            }}
+                            />
+                        )}
+                        onChange={(event, newValue) => {
+                            if (newValue && newValue.bbox && newValue.bbox.length === 4) {
+                            // trigger zoom to property
+                            let _bbox = newValue.bbox.map(String);
                             dispatch(triggerMapEvent({
                                 'id': uuidv4(),
                                 'name': MapEvents.ZOOM_INTO_PROPERTY,
@@ -454,18 +562,27 @@ function Filter() {
                                 'payload': _bbox
                             }));
                             setSearchInputValue('');
-                        }
-                    }}
+                            }
+                            else if (newValue && newValue.boundingbox && newValue.boundingbox.length === 4) {
+                                let _bbox = newValue.boundingbox.map(String);
+                                dispatch(triggerMapEvent({
+                                    'id': uuidv4(),
+                                    'name': MapEvents.ZOOM_INTO_PROPERTY,
+                                    'date': Date.now(),
+                                    'payload': _bbox
+                                }));
+                                setSearchInputValue('');
+                            }
+                        }}
 
-                    onInputChange={(event, newInputValue) => {
-                        setSearchInputValue(newInputValue);
-                        handleInputChange(newInputValue);
-                    }}
-                    filterOptions={(x) => x}
-                    isOptionEqualToValue={(option, value) => option.id === value.id}
-                />
-            </Box>
-            <Box className='sidebarBox'>
+                        onInputChange={(event, newInputValue) => {
+                            setSearchInputValue(newInputValue);
+                            handleInputChange(newInputValue);
+                        }}
+                        filterOptions={(x) => x}
+                        isOptionEqualToValue={(option, value) => option.id === value.id}
+                    />
+                </Box>
                 {(userRole === "National data scientist" || userRole === "Regional data scientist" || userRole === "Super user") && <Box>
                     <Box className='sidebarBoxHeading'>
                         <img src="/static/images/organisation.svg" alt='Organisation image' />


### PR DESCRIPTION
[Screencast from 29-09-2023 13:16:20.webm](https://github.com/kartoza/sawps/assets/70011086/ef658ed5-3a72-4054-8237-ff165f348ea7)

Description:
on the explore page in the sidebar panel filters section
a user can select a property and doing so will trigger a navigation to the properties location on the map
a user can select multiple properties and it will adjust the maps focus to the area that covers the properties selected
a user can select all properties and it will readjust the map accordingly 
deselecting all properties will restore the map to its intial state when the component is loaded 
the search box styling has been improved to match the styling of the other checkboxes on the page