### PR TITLE
Remove parent farm from search parcel

### DIFF
--- a/django_project/frontend/utils/upload_file.py
+++ b/django_project/frontend/utils/upload_file.py
@@ -20,14 +20,12 @@ from frontend.models.base_task import (
 from frontend.models.parcels import (
     Erf,
     Holding,
-    FarmPortion,
-    ParentFarm
+    FarmPortion
 )
 from frontend.serializers.parcel import (
     ErfParcelSerializer,
     HoldingParcelSerializer,
-    FarmPortionParcelSerializer,
-    ParentFarmParcelSerializer
+    FarmPortionParcelSerializer
 )
 from frontend.models.boundary_search import (
     BoundarySearchRequest,
@@ -37,11 +35,12 @@ from frontend.models.boundary_search import (
 from frontend.utils.parcel import find_parcel_base
 
 
+# when searching for parcels,
+# we can ignore ParentFarm because it is broken down to FarmPortion
 PARCEL_SERIALIZER_MAP = {
     Erf: ErfParcelSerializer,
     Holding: HoldingParcelSerializer,
-    FarmPortion: FarmPortionParcelSerializer,
-    ParentFarm: ParentFarmParcelSerializer
+    FarmPortion: FarmPortionParcelSerializer
 }
 
 fiona.drvsupport.supported_drivers['KML'] = 'ro'


### PR DESCRIPTION
@amyburness @Jeremy-Prior  In the frontend, I have a logic that will exclude ParentFarm parcel from selection. I remember I discussed it with Jeremy, because the ParentFarm is actually broken down to smaller parcel in FarmPortion.
This PR will also exclude ParentFarm for searching parcel during: shapefile upload and digitise function.
Below is the issue that I encountered, I have these parcels from digitise function:

![Screenshot_4710](https://github.com/kartoza/sawps/assets/5819076/4c786a17-87d3-4ae9-abe7-701ad319ff30)

But, after clicking save boundary, property geometry is added with ParentFarm parcel too.

![Screenshot_4711](https://github.com/kartoza/sawps/assets/5819076/e0f365ce-1d35-47e0-b9cd-329e3cddbb5b)

Let me know if this PR makes sense,