### PR TITLE
Feature/1255: Activity Type

### DIFF
--- a/django_project/activity/admin.py
+++ b/django_project/activity/admin.py
@@ -8,11 +8,17 @@ from django.utils.html import format_html
 from activity.models import ActivityType
 from activity.forms import ActivityTypeForm
 
+
 class ActivityTypeAdmin(admin.ModelAdmin):
     """Admin page for Activity Type model
 
     """
-    list_display = ('name', 'recruitment', 'display_color', 'display_export_fields')
+    list_display = [
+        'name',
+        'recruitment',
+        'display_color',
+        'display_export_fields'
+    ]
     form = ActivityTypeForm
 
     def display_export_fields(self, obj):

--- a/django_project/activity/admin.py
+++ b/django_project/activity/admin.py
@@ -4,6 +4,27 @@
 """Admin for activity package.
 """
 from django.contrib import admin
-from .models import ActivityType
+from django.utils.html import format_html
+from activity.models import ActivityType
+from activity.forms import ActivityTypeForm
 
-admin.site.register(ActivityType)
+class ActivityTypeAdmin(admin.ModelAdmin):
+    """Admin page for Activity Type model
+
+    """
+    list_display = ('name', 'recruitment', 'display_color', 'display_export_fields')
+    form = ActivityTypeForm
+
+    def display_export_fields(self, obj):
+        return ', '.join(obj.export_fields)
+
+    def display_color(self, obj):
+        return format_html(
+            '<span style="width:10px;height:10px;'
+            'display:inline-block;background-color:%s"></span>' % obj.colour
+        )
+    display_color.short_description = 'Colour'
+    display_color.allow_tags = True
+
+
+admin.site.register(ActivityType, ActivityTypeAdmin)

--- a/django_project/activity/forms.py
+++ b/django_project/activity/forms.py
@@ -1,0 +1,15 @@
+from django.forms import ModelForm
+from django.forms.widgets import TextInput
+from activity.models import ActivityType
+
+
+class ActivityTypeForm(ModelForm):
+    """
+    Activity Type form.
+    """
+    class Meta:
+        model = ActivityType
+        fields = '__all__'
+        widgets = {
+            'colour': TextInput(attrs={'type': 'color'}),
+        }

--- a/django_project/activity/models.py
+++ b/django_project/activity/models.py
@@ -11,9 +11,21 @@ class ActivityType(models.Model):
 
     name = models.CharField(max_length=150, unique=True)
     recruitment = models.BooleanField(null=True, blank=True)
+    colour = models.CharField(max_length=20, null=True, blank=True)
+    export_fields = models.JSONField(
+        default=list,
+        help_text=(
+            'Fields that will be taken from Annual Population Per Activity table '
+            'when exporting Activity Report. Input as Array e.g. ["intake_permit", "translocation_destination"]'
+        )
+    )
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def get_all_activities(cls):
+        return list(cls.objects.values_list('name', flat=True).order_by('name'))
 
     class Meta:
         verbose_name = 'Activity'

--- a/django_project/activity/models.py
+++ b/django_project/activity/models.py
@@ -15,8 +15,10 @@ class ActivityType(models.Model):
     export_fields = models.JSONField(
         default=list,
         help_text=(
-            'Fields that will be taken from Annual Population Per Activity table '
-            'when exporting Activity Report. Input as Array e.g. ["intake_permit", "translocation_destination"]'
+            'Fields that will be taken from Annual Population '
+            'Per Activity table when exporting Activity Report. '
+            'Input as Array e.g. '
+            '["intake_permit", "translocation_destination"]'
         )
     )
 
@@ -25,7 +27,9 @@ class ActivityType(models.Model):
 
     @classmethod
     def get_all_activities(cls):
-        return list(cls.objects.values_list('name', flat=True).order_by('name'))
+        return list(cls.objects.values_list(
+            'name', flat=True
+        ).order_by('name'))
 
     class Meta:
         verbose_name = 'Activity'

--- a/django_project/activity/urls.py
+++ b/django_project/activity/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+
+from activity.views import ActivityTypeAPIView
+
+# views urls
+urlpatterns = [  # '',
+    path(
+        'api/activity-type/',
+        ActivityTypeAPIView.as_view(),
+        name='activity-type'
+    )
+]

--- a/django_project/activity/views.py
+++ b/django_project/activity/views.py
@@ -1,7 +1,8 @@
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
-from activity.models import ActivityType
 from rest_framework.response import Response
+from activity.models import ActivityType
+from activity.serializers import ActivityTypeSerializer
 
 
 class ActivityTypeAPIView(APIView):
@@ -9,8 +10,8 @@ class ActivityTypeAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
-        queryset = ActivityType.get_all_activities()
+        queryset = ActivityType.objects.all().order_by('name')
         return Response(
             status=200,
-            data=queryset
+            data=ActivityTypeSerializer(queryset, many=True).data
         )

--- a/django_project/activity/views.py
+++ b/django_project/activity/views.py
@@ -1,3 +1,16 @@
-# from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+from activity.models import ActivityType
+from rest_framework.response import Response
 
-# Create your views here.
+
+class ActivityTypeAPIView(APIView):
+    """Get Activity Type"""
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        queryset = ActivityType.get_all_activities()
+        return Response(
+            status=200,
+            data=queryset
+        )

--- a/django_project/core/urls.py
+++ b/django_project/core/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('', include('frontend.urls')),
     path('admin/', admin.site.urls),
     path('', include('notification.urls')),
+    path('', include('activity.urls')),
     path('', include('stakeholder.urls')),
     path('', include('sawps.urls')),
     path('', include('species.urls'))

--- a/django_project/fixtures/activity_type.json
+++ b/django_project/fixtures/activity_type.json
@@ -20,7 +20,8 @@
     "pk": 3,
     "fields": {
         "name": "Planned Euthanasia/DCA",
-        "recruitment": null
+        "recruitment": null,
+        "export_fields": ["intake_permit"]
     }
 },
 {
@@ -28,7 +29,8 @@
     "pk": 4,
     "fields": {
         "name": "Planned Hunt/Cull",
-        "recruitment": null
+        "recruitment": null,
+        "export_fields": ["intake_permit"]
     }
 },
 {
@@ -36,7 +38,12 @@
     "pk": 5,
     "fields": {
         "name": "Translocation (Intake)",
-        "recruitment": null
+        "recruitment": null,
+        "export_fields": [
+            "intake_permit",
+            "translocation_destination",
+            "offtake_permit"
+        ]
     }
 },
     {
@@ -44,7 +51,12 @@
     "pk": 6,
     "fields": {
         "name": "Translocation (Offtake)",
-        "recruitment": null
+        "recruitment": null,
+        "export_fields": [
+            "translocation_destination",
+            "founder_population",
+            "reintroduction_source"
+        ]
     }
 }
 ]

--- a/django_project/frontend/serializers/report.py
+++ b/django_project/frontend/serializers/report.py
@@ -182,7 +182,9 @@ class ActivityReportSerializer(
         super().__init__(*args, **kwargs)
 
         try:
-            activity_fields = ActivityType.objects.get(name__iexact=activity_name).export_fields
+            activity_fields = ActivityType.objects.get(
+                name__iexact=activity_name
+            ).export_fields
         except ActivityType.DoesNotExist:
             activity_fields = []
 

--- a/django_project/frontend/serializers/report.py
+++ b/django_project/frontend/serializers/report.py
@@ -5,6 +5,7 @@ from population_data.models import (
     AnnualPopulation,
     AnnualPopulationPerActivity
 )
+from activity.models import ActivityType
 from species.models import OwnedSpecies
 
 
@@ -180,25 +181,17 @@ class ActivityReportSerializer(
             raise ValueError("'activity_name' argument is required!")
         super().__init__(*args, **kwargs)
 
-        activity_data_map = {
-            "Unplanned/illegal hunting": [],
-            "Planned euthanasia": ["intake_permit"],
-            "Planned hunt/cull": ["intake_permit"],
-            "Planned translocation": [
-                "intake_permit", "translocation_destination",
-                "offtake_permit"
-            ],
-            "Unplanned/natural deaths": [
-                "translocation_destination", "founder_population",
-                "reintroduction_source"
-            ],
-        }
+        try:
+            activity_fields = ActivityType.objects.get(name__iexact=activity_name).export_fields
+        except ActivityType.DoesNotExist:
+            activity_fields = []
+
         base_fields = [
             "property_name", "scientific_name", "common_name",
             "year", "total", "adult_male", "adult_female",
             "juvenile_male", "juvenile_female"
         ]
-        valid_fields = base_fields + activity_data_map[activity_name]
+        valid_fields = base_fields + activity_fields
         allowed = set(valid_fields)
         existing = set(self.fields.keys())
         for field_name in existing - allowed:

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -43,6 +43,7 @@ const FETCH_AVAILABLE_SPECIES = '/species/'
 const FETCH_PROPERTY_LIST_URL = '/api/property/list/'
 const SEARCH_PROPERTY_URL = '/api/property/search'
 const FETCH_ORGANISATION_LIST_URL = '/api/organisation/'
+const FETCH_ACTIVITY_LIST_URL = '/api/activity-type/'
 const FETCH_PROPERTY_DETAIL_URL = '/api/property/detail/'
 
 interface SearchPropertyResult {
@@ -74,6 +75,7 @@ function Filter(props: any) {
     const [searchInputValue, setSearchInputValue] = useState<string>('')
     const [searchResults, setSearchResults] = useState<SearchPropertyResult[]>([])
     const [organisationList, setOrganisationList] = useState([]);
+    const [activityList, setActivityList]= useState<string[]>([]);
     const [selectedOrganisation, setSelectedOrganisation] = useState([]);
     const [tab, setTab] = useState<string>('')
     const [searchSpeciesList, setSearchSpeciesList] = useState([])
@@ -194,7 +196,6 @@ function Filter(props: any) {
         }
       };
 
-    const [activityList,setActivityList]= useState<string[]>(["Planned euthanasia", "Planned hunt/cull", "Planned translocation", "Unplanned/illegal hunting", "Unplanned/natural deaths"])
     const [filterlList, setFilterList] = useState([
         {
             "id": 5,
@@ -283,10 +284,24 @@ function Filter(props: any) {
         })
     }
 
+    const fetchActivityList = () => {
+        setLoading(true)
+        axios.get(FETCH_ACTIVITY_LIST_URL).then((response) => {
+            setLoading(false)
+            if (response.data) {
+                setActivityList(response.data)
+            }
+        }).catch((error) => {
+            setLoading(false)
+            console.log(error)
+        })
+    }
+
     useEffect(() => {
         fetchSpeciesList();
         fetchPropertyList();
         fetchOrganisationList();
+        fetchActivityList();
     }, [])
 
     const handleSelectedSpecies = (value: string) => {

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -289,7 +289,7 @@ function Filter(props: any) {
         axios.get(FETCH_ACTIVITY_LIST_URL).then((response) => {
             setLoading(false)
             if (response.data) {
-                setActivityList(response.data)
+                setActivityList(response.data.map((activity: any) => activity.name))
             }
         }).catch((error) => {
             setLoading(false)

--- a/django_project/frontend/tests/test_activity_types.py
+++ b/django_project/frontend/tests/test_activity_types.py
@@ -1,0 +1,82 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django_otp.plugins.otp_totp.models import TOTPDevice
+from rest_framework import status
+
+
+class TestOrganisationAPIView(TestCase):
+    fixtures = [
+        'activity_type.json'
+    ]
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser',
+            password='testpassword'
+        )
+        device = TOTPDevice(
+            user=self.user,
+            name='device_name'
+        )
+        device.save()
+        self.client.login(username='testuser', password='testpassword')
+
+    def test_list_activity_types(self):
+        url = reverse('activity-type')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_response = [
+            {
+                "id": 1,
+                "name": "Other",
+                "recruitment": None,
+                "colour": None,
+                "export_fields": [],
+            },
+            {
+                "id": 3,
+                "name": "Planned Euthanasia/DCA",
+                "recruitment": None,
+                "colour": None,
+                "export_fields": ["intake_permit"],
+            },
+            {
+                "id": 4,
+                "name": "Planned Hunt/Cull",
+                "recruitment": None,
+                "colour": None,
+                "export_fields": ["intake_permit"],
+            },
+            {
+                "id": 5,
+                "name": "Translocation (Intake)",
+                "recruitment": None,
+                "colour": None,
+                "export_fields": [
+                    "intake_permit",
+                    "translocation_destination",
+                    "offtake_permit",
+                ],
+            },
+            {
+                "id": 6,
+                "name": "Translocation (Offtake)",
+                "recruitment": None,
+                "colour": None,
+                "export_fields": [
+                    "translocation_destination",
+                    "founder_population",
+                    "reintroduction_source",
+                ],
+            },
+            {
+                "id": 2,
+                "name": "Unplanned/Illegal Hunting",
+                "recruitment": None,
+                "colour": None,
+                "export_fields": [],
+            },
+        ]
+
+        self.assertEqual(response.json(), expected_response)

--- a/django_project/frontend/utils/data_table.py
+++ b/django_project/frontend/utils/data_table.py
@@ -5,6 +5,7 @@ from django.db.models import Sum
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
 
+from activity.models import ActivityType
 from frontend.serializers.report import (
     SpeciesReportSerializer,
     SamplingReportSerializer,
@@ -115,11 +116,7 @@ def get_report_filter(request, report_type):
         if activity:
             activity_types = [activity]
         else:
-            activity_types = [
-                "Planned euthanasia", "Planned hunt/cull",
-                "Planned translocation", "Unplanned/natural deaths",
-                "Unplanned/illegal hunting"
-            ]
+            activity_types = ActivityType.get_all_activities()
         filters[activity_fields[report_type]] = activity_types
     return filters
 
@@ -203,13 +200,7 @@ def activity_report(queryset: QuerySet, request) -> Dict[str, List[Dict]]:
     activity_reports = {
         activity: [] for activity in activity_types
     }
-    valid_activity_types = {
-        'Unplanned/illegal hunting',
-        'Planned euthanasia',
-        'Planned hunt/cull',
-        'Planned translocation',
-        'Unplanned/natural deaths'
-    }
+    valid_activity_types = set(ActivityType.get_all_activities())
     valid_activities = set(activity_types).intersection(valid_activity_types)
     for activity_name in valid_activities:
         activity_data = AnnualPopulationPerActivity.objects.filter(


### PR DESCRIPTION
This PR is for #1255 .
What I added:
- [ ] New fields in Activity Table to list applicable export fields and colour.
- [ ] Endpoint to get all activity types.
- [ ] Use the endpoint to list activity type on frontend (previously was hardoced).
- [ ] Get activity type from database when exporting activity report (previously was hardoced).


[Kazam_screencast_00028.webm](https://github.com/kartoza/sawps/assets/7352963/16085470-c45c-4e94-a277-b2e772eb8c29)

