### PR TITLE
Add donut charts

### DIFF
--- a/django_project/frontend/api_views/metrics.py
+++ b/django_project/frontend/api_views/metrics.py
@@ -16,6 +16,7 @@ from frontend.serializers.metrics import (
     TotalCountPerActivitySerializer,
     PopulationPerAgeGroupSerialiser,
     TotalAreaVSAvailableAreaSerializer,
+    TotalCountPerPopulationEstimateSerializer
 )
 from frontend.utils.metrics import (
     calculate_population_categories,
@@ -101,6 +102,21 @@ class ActivityPercentageAPIView(APIView):
             queryset, many=True, context={"request": request}
         )
         return Response(calculate_base_population_of_species(serializer.data))
+
+
+class TotalCountPerPopulationEstimateAPIView(APIView):
+    """
+    API view to retrieve total counts per population
+    estimate category for species.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs) -> Response:
+        serializer = TotalCountPerPopulationEstimateSerializer(
+            context={"request": request}
+        )
+        result = serializer.get_total_counts_per_population_estimate()
+        return Response(result)
 
 
 class TotalCountPerActivityAPIView(APIView):

--- a/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from "react";
+import { Doughnut } from "react-chartjs-2";
+import { CategoryScale } from "chart.js";
+import Chart from "chart.js/auto";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import Loading from "../../../components/Loading";
+import "./index.scss";
+
+Chart.register(CategoryScale);
+Chart.register(ChartDataLabels);
+
+interface ActivityItem {
+  activity_type: string;
+  year: number;
+  total: number;
+}
+
+interface ActivityDataItem {
+  species_name: string;
+  activities: ActivityItem[];
+  total: number;
+}
+
+interface Props {
+  selectedSpecies: string;
+  startYear: number;
+  endYear: number;
+  loading: boolean;
+  activityData: ActivityDataItem[];
+}
+
+const availableColors = [
+  'rgba(112, 178, 118, 1)',
+  'rgba(250, 167, 85, 1)',
+  'rgba(157, 133, 190, 1)',
+  '#FF5252',
+  '#616161',
+  // additional transparency colors for years
+  'rgba(112, 178, 118, 0.5)', // 50% transparency
+  'rgba(255, 82, 82, 0.5)', // 50% transparency
+  'rgba(97, 97, 97, 0.5)', // 50% transparency
+  'rgba(157, 133, 190, 0.5)', // 50% transparency
+  'rgba(250, 167, 85, 0.5)', // 50% transparency
+];
+
+const ActivityCountAsPercentage: React.FC<Props> = ({
+  selectedSpecies,
+  startYear,
+  endYear,
+  loading,
+  activityData,
+}: Props) => {
+  // Initialize variables
+  const labels: string[] = [];
+  const data: string[] = [];
+  const uniqueColors: string[] = [];
+  let year: number | null = null; //use effect to update this guy
+  const recentActivitiesMap: Record<string, any> = {};
+
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
+
+  if (!selectedSpecies || !activityData || activityData.length === 0) {
+    return null; // Return null if the condition fails
+  }
+
+
+  // Iterate through activityData
+  activityData.forEach((speciesData: ActivityDataItem) => {
+    if (speciesData.species_name.toLocaleLowerCase() !== selectedSpecies.toLocaleLowerCase()) {
+      // Rule 1: If species doesn't match, assign null data
+      year = null;
+      return;
+    }
+
+    const speciesActivities = speciesData.activities;
+
+    // Iterate through activities to find the most recent year
+    speciesActivities.forEach((activity: ActivityItem) => {
+      if (year === null || activity.year > year) {
+        year = activity.year;
+      }
+    });
+
+    // Rule 3: If the year doesn't match startYear or endYear, use the most recent year
+    if (year !== null && (year < startYear || year > endYear)) {
+      year = null;
+    }
+
+    // Rule 2: Only save the activities with the most recent year
+    const recentActivities = speciesActivities.filter(
+      (activity: ActivityItem) => activity.year === year
+    );
+
+    // Get the total for the most recent year
+    const totalForMostRecentYear = speciesData.total;
+
+    // Rule 4: Store activities in a cleaner object and calculate percentages
+    recentActivities.forEach((recentActivity: ActivityItem) => {
+      const activityType = recentActivity.activity_type;
+      const total = recentActivity.total;
+
+      // Calculate the percentage using the total from the most recent year
+      const percentage = ((total / totalForMostRecentYear) * 100).toFixed(2) ;//+ "%";
+
+      // Rule 4: Save unique activity types
+      // Check if the activityType is not in the labels list
+      if (!labels.includes(activityType)) {
+        // Remove text before "/" to get text after "/"
+        // const modifiedLabel = activityType.split('/').pop(); // Get text after "/"
+        const paddedLabel = activityType.padEnd(50, ' '); // Pad with spaces
+          
+        labels.push(paddedLabel); // Use the padded label
+        // labels.push(activityType); // Use modified label or the original if there's no text after "/"
+        data.push(percentage);
+        uniqueColors.push(availableColors[labels.length - 1]);
+     }
+      
+
+      // Rule 4: Store activities in a cleaner object
+      if (!recentActivitiesMap[activityType]) {
+        recentActivitiesMap[activityType] = {
+          total: 0,
+          year: year,
+        };
+      }
+      recentActivitiesMap[activityType].total += total;
+    });
+  });
+
+  // Create the chartData object
+  const chartData = {
+    labels: labels,
+    datasets: [
+      {
+        data: data,
+        backgroundColor: uniqueColors,
+      },
+    ],
+  };
+
+  const options = {
+    cutout: "54%",
+    plugins: {
+      legend: {
+        position: "right" as "right",
+        display: true,
+        labels: {
+          boxWidth: 20,
+          boxHeight: 13,
+          padding: 12,
+          font: {
+            size: 12,
+          },
+        },
+      },
+      datalabels: {
+        color: "#fff",
+        formatter: (value: number) => {
+            return `${value}%`;
+        },
+        font: {
+          size: 12,
+        },
+      },
+      title: {
+        display: true,
+        text: year
+          ? `Activity count as % of total population for ${selectedSpecies} year ${year}`
+          : `No data available for ${selectedSpecies} current filter selections`,
+        align: 'start' as 'start',
+        font: {
+          size: 16,
+          weight: 'bold' as 'bold',
+        },
+      },
+    },
+  };
+
+  // custom styling for donut charts
+  const chartContainerStyle: React.CSSProperties = {
+    position: "relative",
+    backgroundImage: `url(${backgroundImageUrl})`,
+    backgroundSize: "20% 24%", // width and height of image
+    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+    backgroundRepeat: "no-repeat",
+    whiteSpace: "pre-wrap", // Allow text to wrap
+  };
+
+  return (
+    <>
+      {!loading ? (
+          <Doughnut
+            data={chartData}
+            options={options}
+            style={chartContainerStyle}
+          />
+      ) : (
+        <Loading containerStyle={{ minHeight: 160 }} />
+      )}
+    </>
+  );
+};
+
+export default ActivityCountAsPercentage;

--- a/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
@@ -112,6 +112,9 @@ const DensityBarChart = (props: any) => {
     // Remove duplicate years
     const uniqueYears = Array.from(new Set(yearsInData));
 
+    // Sort the years from highest to lowest
+    uniqueYears.sort((a: number, b: number) => b - a);
+
     // Create datasets for each year using available colors
     const datasets = uniqueYears.map((year: any, index: number) => {
         const backgroundColor = colors[index % colors.length];

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationCategoryChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationCategoryChart.tsx
@@ -104,8 +104,17 @@ const PopulationCategoryChart = (props: any) => {
         });
     }
 
-    // Sort labels in ascending order
-    labels.sort((a: any, b: any) => parseInt(a) - parseInt(b));
+    // Sort labels in ascending order (lowest year first)
+    // Custom sorting function to handle numerical ranges
+    const customSort = (a: string, b: string): number => {
+        const [minA, maxA] = a.split(/-|>/).map((num) => parseInt(num, 10) || 0);
+        const [minB, maxB] = b.split(/-|>/).map((num) => parseInt(num, 10) || 0);
+    
+      // Compare based on the maximum values
+      return maxA - maxB;
+    };
+
+    labels.sort(customSort);
 
     // Sort datasets in descending order
     newDatasets.sort((a, b) => parseInt(b.label) - parseInt(a.label));

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from "react";
+import { Doughnut } from "react-chartjs-2";
+import { CategoryScale } from "chart.js";
+import Chart from "chart.js/auto";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import Loading from "../../../components/Loading";
+import axios from "axios";
+import "./index.scss";
+
+Chart.register(CategoryScale);
+Chart.register(ChartDataLabels);
+
+const FETCH_POPULATION_ESTIMATE_CATEGORY_COUNT = "/api/total-count-per-population-estimate/";
+
+const availableColors = [
+  'rgba(112, 178, 118, 1)',
+  'rgba(250, 167, 85, 1)',
+  'rgba(157, 133, 190, 1)',
+  '#FF5252',
+  '#616161',
+  // additional transparency colors for years
+  'rgba(112, 178, 118, 0.5)', // 50% transparency
+  'rgba(255, 82, 82, 0.5)', // 50% transparency
+  'rgba(97, 97, 97, 0.5)', // 50% transparency
+  'rgba(157, 133, 190, 0.5)', // 50% transparency
+  'rgba(250, 167, 85, 0.5)', // 50% transparency
+];
+
+const PopulationEstimateCategoryCount = (props: any) => {
+  const {
+    selectedSpecies,
+    propertyId,
+    startYear,
+    endYear,
+    loading,
+    setLoading,
+  } = props;
+  let year: number | null = null;
+  const [speciesData, setSpeciesData] = useState([]);
+
+  const fetchPopulationEstimateCategoryCount = () => {
+    setLoading(true);
+    axios
+      .get(
+        `${FETCH_POPULATION_ESTIMATE_CATEGORY_COUNT}?start_year=${startYear}&end_year=${endYear}&species=${selectedSpecies}&property=${propertyId}`
+      )
+      .then((response) => {
+        if (response.data) {
+          setSpeciesData(response.data);
+          setLoading(false);
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchPopulationEstimateCategoryCount();
+  }, [propertyId, startYear, endYear, selectedSpecies]);
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
+
+  if (!selectedSpecies) {
+    return null; // Return null if the condition fails
+  }
+
+
+  // Initialize variables
+  const labels: string[] = [];
+  const data: number[] = [];
+  const uniqueColors: string[] = [];
+
+  // Iterate through the keys of speciesData
+  for (const category in speciesData) {
+    if (speciesData.hasOwnProperty(category)) {
+      const categoryData = speciesData[category];
+      const count = categoryData.count;
+      year = categoryData.years[0];
+
+      const paddedLabel = category.padEnd(50, ' '); // Pad with spaces
+          
+      labels.push(paddedLabel); // Use the padded label
+
+      // labels.push(category);
+      data.push(count);
+      uniqueColors.push(availableColors[labels.length - 1]);
+    }
+  }
+
+  // Create the chartData object
+  const chartData = {
+    labels: labels,
+    datasets: [
+      {
+        data: data,
+        backgroundColor: uniqueColors,
+      },
+    ],
+  };
+
+  // Create chart title
+  let chartTitle = "Please select a species for the chart to show available data";
+
+  if (selectedSpecies) {
+    if (Object.keys(speciesData).length > 0) {
+      chartTitle = `Total count per population estimate category for ${selectedSpecies}`;
+      if (year) {
+        chartTitle += ` year ${year}`;
+      }
+    } else {
+      setBackgroundImageUrl('')
+      chartTitle = "No data available for current filter selections";
+    }
+  }
+
+  const options = {
+    cutout: "54%",
+    plugins: {
+      legend: {
+        position: "right" as "right",
+        display: true,
+        labels: {
+          boxWidth: 20,
+          boxHeight: 13,
+          padding: 12,
+          font: {
+            size: 12,
+          },
+        },
+      },
+      datalabels: {
+        color: "#fff",
+        font: {
+          size: 12,
+        },
+      },
+      title: {
+        display: true,
+        text: chartTitle,
+        align: 'start' as 'start',
+        font: {
+          size: 16,
+          weight: 'bold' as 'bold',
+        },
+      },
+    },
+  };
+
+  // custom styling for donut charts
+  const chartContainerStyle: React.CSSProperties = {
+    position: "relative",
+    backgroundImage: `url(${backgroundImageUrl})`,
+    backgroundSize: "20% 24%", // width and height of image
+    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+    backgroundRepeat: "no-repeat",
+    whiteSpace: "pre-wrap", // Allow text to wrap
+  };
+
+  return (
+    <>
+      {!loading ? (
+          <Doughnut
+            data={chartData}
+            options={options}
+            style={chartContainerStyle}
+          />
+      ) : (
+        <Loading containerStyle={{ minHeight: 160 }} />
+      )}
+    </>
+  );
+};
+
+
+export default PopulationEstimateCategoryCount;

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useState } from "react";
+import { Doughnut } from "react-chartjs-2";
+import { CategoryScale } from "chart.js";
+import Chart from "chart.js/auto";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import Loading from "../../../components/Loading";
+import axios from "axios";
+import "./index.scss";
+
+Chart.register(CategoryScale);
+Chart.register(ChartDataLabels);
+
+const FETCH_POPULATION_ESTIMATE_CATEGORY_COUNT = "/api/total-count-per-population-estimate/";
+
+const availableColors = [
+  'rgba(112, 178, 118, 1)',
+  'rgba(250, 167, 85, 1)',
+  'rgba(157, 133, 190, 1)',
+  '#FF5252',
+  '#616161',
+  // additional transparency colors for years
+  'rgba(112, 178, 118, 0.5)', // 50% transparency
+  'rgba(255, 82, 82, 0.5)', // 50% transparency
+  'rgba(97, 97, 97, 0.5)', // 50% transparency
+  'rgba(157, 133, 190, 0.5)', // 50% transparency
+  'rgba(250, 167, 85, 0.5)', // 50% transparency
+];
+
+const PopulationEstimateAsPercentage = (props: any) => {
+  const {
+    selectedSpecies,
+    propertyId,
+    startYear,
+    endYear,
+    loading,
+    setLoading,
+  } = props;
+
+  const [speciesData, setSpeciesData] = useState<any>({});
+
+  const fetchPopulationEstimateCategoryCount = () => {
+    setLoading(true);
+    axios
+      .get(
+        `${FETCH_POPULATION_ESTIMATE_CATEGORY_COUNT}?start_year=${startYear}&end_year=${endYear}&species=${selectedSpecies}&property=${propertyId}`
+      )
+      .then((response) => {
+        if (response.data) {
+          setSpeciesData(response.data);
+          setLoading(false);
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchPopulationEstimateCategoryCount();
+  }, [propertyId, startYear, endYear, selectedSpecies]);
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
+
+
+  if (!selectedSpecies) {
+    return null; // Return null if the condition fails
+  }
+
+  // Initialize variables
+  const labels: string[] = [];
+  const data: number[] = [];
+  const uniqueColors: string[] = [];
+  let year: number | null = null;
+
+  // Iterate through the keys of speciesData
+  for (const category in speciesData) {
+    if (speciesData.hasOwnProperty(category)) {
+      const categoryData = speciesData[category];
+      const percentage = categoryData.percentage;
+      year = categoryData.years[0];
+
+      const paddedLabel = category.padEnd(50, ' '); // Pad with spaces
+          
+      labels.push(paddedLabel); // Use the padded label
+
+      // labels.push(category);
+      data.push(percentage);
+      uniqueColors.push(availableColors[labels.length - 1]);
+    }
+  }
+
+  // Create the chartData object
+  const chartData = {
+    labels: labels,
+    datasets: [
+      {
+        data: data,
+        backgroundColor: uniqueColors,
+      },
+    ],
+  };
+
+  // Create chart title
+  let chartTitle = `Population estimate category count as % of the total population for ${selectedSpecies} year ${year}`;
+
+  if (!selectedSpecies) {
+    chartTitle = "Please select a species for the chart to show available data";
+  } else if (Object.keys(speciesData).length === 0) {
+    chartTitle = "No data available for current filter selections";
+    setBackgroundImageUrl('')
+  }
+
+  const options = {
+    cutout: "54%",
+    plugins: {
+      legend: {
+        position: "right" as "right",
+        display: true,
+        labels: {
+          boxWidth: 20,
+          boxHeight: 13,
+          padding: 12,
+          font: {
+            size: 12,
+          },
+        },
+      },
+      datalabels: {
+        color: "#fff",
+        formatter: (value: number) => {
+          return `${value.toFixed(2)}%`;
+        },
+        font: {
+          size: 12,
+        },
+      },
+      title: {
+        display: true,
+        text: chartTitle,
+        align: 'start' as 'start',
+        font: {
+          size: 16,
+          weight: 'bold' as 'bold',
+        },
+      },
+    },
+  };
+
+  // custom styling for donut charts
+  const chartContainerStyle: React.CSSProperties = {
+    position: "relative",
+    backgroundImage: `url(${backgroundImageUrl})`,
+    backgroundSize: "20% 24%", // width and height of image
+    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+    backgroundRepeat: "no-repeat",
+    whiteSpace: "pre-wrap", // Allow text to wrap
+  };
+
+    return (
+      <>
+        {!loading ? (
+            <Doughnut
+              data={chartData}
+              options={options}
+              style={chartContainerStyle}
+            />
+        ) : (
+          <Loading containerStyle={{ minHeight: 160 }} />
+        )}
+      </>
+    );
+};
+
+export default PopulationEstimateAsPercentage;

--- a/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountPerProvinceChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountPerProvinceChart.tsx
@@ -81,6 +81,9 @@ const SpeciesCountPerProvinceChart = (props: any) => {
   const legendLabels: number[] = Array.from(new Set(speciesData.map((item) => item.year)))
     .filter((year) => year !== null) as number[];
 
+  // sort the years from highest 
+  legendLabels.sort((a: number, b: number) => b - a);
+
     const datasets = legendLabels.map((year, yearIndex) => {
       const backgroundColor = availableColors[yearIndex];
   

--- a/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from "react";
+import { Doughnut } from "react-chartjs-2";
+import { CategoryScale } from "chart.js";
+import Chart from "chart.js/auto";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import Loading from "../../../components/Loading";
+import "./index.scss";
+
+
+
+Chart.register(CategoryScale);
+Chart.register(ChartDataLabels);
+
+interface SpeciesDataItem {
+    province: string;
+    species: string;
+    year: number | null;
+    count: number | null;
+}
+
+  const availableColors = [
+    'rgba(112, 178, 118, 1)', 
+    'rgba(250, 167, 85, 1)', 
+    'rgba(157, 133, 190, 1)', 
+    '#FF5252', 
+    '#616161',
+    // additional transparency colors for years
+    'rgba(112, 178, 118, 0.5)',  // 50% transparency
+    'rgba(255, 82, 82, 0.5)',  // 50% transparency
+    'rgba(97, 97, 97, 0.5)',  // 50% transparency
+    'rgba(157, 133, 190, 0.5)',  // 50% transparency
+    'rgba(250, 167, 85, 0.5)',  // 50% transparency
+  ];
+  
+
+  const TotalCountPerActivity = (props: any) => {
+    const {
+      selectedSpecies,
+      loading,
+      activityData
+    } = props;
+    const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
+
+    // Add a condition to check if the selectedSpecies and activityData meet your criteria
+    if (!selectedSpecies || !activityData || activityData.length === 0) {
+        return null; // Return null if the condition fails
+    }
+  
+    // Initialize variables
+    const labels: string[] = [];
+    const data: number[] = [];
+    const uniqueColors: string[] = [];
+    let year: number = 0;
+  
+    if (activityData && activityData.length > 0) {
+      // Iterate through activityData
+      activityData.forEach((speciesData: any) => {
+        const speciesActivities = speciesData.activities;
+        const latestActivity = speciesActivities.reduce(
+          (maxActivity: any, currentActivity: any) =>
+            currentActivity.year > maxActivity.year ? currentActivity : maxActivity,
+          speciesActivities[0]
+        );
+  
+        const activityType = latestActivity.activity_type;
+        const total = latestActivity.total;
+        year = latestActivity.year;
+  
+        // Check if the activityType is not in the labels list
+        if (!labels.includes(activityType)) {
+            // Ensure the label is exactly 23 characters long with padding
+            const paddedLabel = activityType.padEnd(50, ' '); // Pad with spaces
+          
+            labels.push(paddedLabel); // Use the padded label
+            data.push(total);
+            uniqueColors.push(availableColors[labels.length - 1]);
+          }          
+      });
+    }
+  
+    // Create the chartData object
+    const chartData = {
+      labels: labels,
+      datasets: [
+        {
+          data: data,
+          backgroundColor: uniqueColors,
+        },
+      ],
+    };
+  
+    // Define chart title based on conditions
+    let chartTitle = 'No data available for current filter selections';
+  
+    if (selectedSpecies && activityData && activityData.length > 0) {
+      chartTitle = `Total count per activity for ${selectedSpecies} year ${year}`;
+    }else {
+        setBackgroundImageUrl('')
+    }
+    
+    if (!selectedSpecies){
+        chartTitle = "Please select a species for the chart to show available data";
+    }
+  
+    const options = {
+      cutout: '54%',
+      plugins: {
+        legend: {
+          position: 'right' as 'right',
+          display: true,
+          labels: {
+            boxWidth: 20,
+            boxHeight: 13,
+            padding: 12,
+            font: {
+              size: 12,
+            },
+          },
+        },
+        datalabels: {
+          color: '#fff',
+          font: {
+            size: 12,
+          },
+        },
+        title: {
+          display: true,
+          text: chartTitle,
+          align: 'start' as 'start',
+          font: {
+            size: 16,
+            weight: 'bold' as 'bold',
+          },
+        },
+      },
+    };
+
+    // custom styling for donut charts
+    const chartContainerStyle: React.CSSProperties = {
+        position: "relative",
+        backgroundImage: `url(${backgroundImageUrl})`,
+        backgroundSize: "20% 24%", // width and height of image
+        backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+        backgroundRepeat: "no-repeat",
+        whiteSpace: "pre-wrap", // Allow text to wrap
+    };
+  
+    return (
+        <>
+          {!loading ? (
+              <Doughnut
+                data={chartData}
+                options={options}
+                style={chartContainerStyle}
+              />
+          ) : (
+            <Loading containerStyle={{ minHeight: 160 }} />
+          )}
+        </>
+      );
+  };
+  
+  export default TotalCountPerActivity;

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -15,7 +15,7 @@ import axios from "axios";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
 import SpeciesCountPerProvinceChart from "./SpeciesCountPerProvinceChart";
-import SpeciesCountAsPercentage from "./SpeciesCountPerProvince%Chart";
+import SpeciesCountAsPercentage from "./SpeciesCountAsPercentage";
 import TotalCountPerActivity from "./TotalCountPerActivity";
 import ActivityCountAsPercentage from "./ActivityCountAsPercentage";
 import PopulationEstimateCategoryCount from "./PopulationEstimateCategory";

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -14,8 +14,13 @@ import AreaAvailableLineChart from "./AreaAvailableLineChart";
 import axios from "axios";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
-import SpeciesCountAsPercentage from "./SpeciesCountAsPercentage";
 import SpeciesCountPerProvinceChart from "./SpeciesCountPerProvinceChart";
+import SpeciesCountAsPercentage from "./SpeciesCountPerProvince%Chart";
+import TotalCountPerActivity from "./TotalCountPerActivity";
+import ActivityCountAsPercentage from "./ActivityCountAsPercentage";
+import PopulationEstimateCategoryCount from "./PopulationEstimateCategory";
+import PopulationEstimateAsPercentage from "./PopulationEstimateCategoryAsPercentage";
+
 
 const FETCH_POPULATION_AGE_GROUP = '/api/population-per-age-group/'
 const FETCH_ACTIVITY_PERCENTAGE_URL = '/api/activity-percentage/'
@@ -226,7 +231,16 @@ const Metrics = () => {
                                 />
                             </Grid>
                   
-                            <Grid item xs={12} md={6}>
+                            <Grid item xs={12} md={6}></Grid>
+                            
+                            <Grid item xs={12} md={6} 
+                                style={{ 
+                                    textAlign: 'center', 
+                                    display: 'flex', 
+                                    alignItems: 'center', 
+                                    justifyContent: 'center' 
+                                }}
+                            >
                                 <SpeciesCountAsPercentage
                                     selectedSpecies={selectedSpecies} 
                                     propertyId={propertyId} 
@@ -237,6 +251,75 @@ const Metrics = () => {
                                     activityData={activityData}
                                 />
                             </Grid>
+
+                            
+                                <Grid item xs={12} md={6}
+                                    style={{ 
+                                        textAlign: 'center', 
+                                        display: 'flex', 
+                                        alignItems: 'center', 
+                                        justifyContent: 'center' 
+                                    }}
+                                >
+                                    <TotalCountPerActivity
+                                        selectedSpecies={selectedSpecies} 
+                                        loading={loading} 
+                                        activityData={totalCoutData}
+                                    />
+                                </Grid>
+
+                                <Grid item xs={12} md={6}
+                                    style={{ 
+                                        textAlign: 'center', 
+                                        display: 'flex', 
+                                        alignItems: 'center', 
+                                        justifyContent: 'center' 
+                                    }}
+                                >
+                                    <ActivityCountAsPercentage
+                                        selectedSpecies={selectedSpecies}
+                                        startYear={startYear} 
+                                        endYear={endYear}
+                                        loading={loading} 
+                                        activityData={totalCoutData}
+                                    />
+                                </Grid>
+
+                                <Grid item xs={12} md={6}
+                                    style={{ 
+                                        textAlign: 'center', 
+                                        display: 'flex', 
+                                        alignItems: 'center', 
+                                        justifyContent: 'center' 
+                                    }}
+                                >
+                                    <PopulationEstimateCategoryCount
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear}
+                                        loading={loading} 
+                                        setLoading={setLoading}
+                                    />
+                                </Grid>
+
+                                <Grid item xs={12} md={6}
+                                    style={{ 
+                                        textAlign: 'center', 
+                                        display: 'flex', 
+                                        alignItems: 'center', 
+                                        justifyContent: 'center' 
+                                    }}
+                                >
+                                    <PopulationEstimateAsPercentage
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear}
+                                        loading={loading} 
+                                        setLoading={setLoading}
+                                    />
+                                </Grid>
 
 
                     </Grid>

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -63,6 +63,30 @@ class BaseTestCase(TestCase):
         session = self.client.session
         session.save()
 
+class PopulationEstimateCategoryTestCase(BaseTestCase):
+    """
+    This is to test if the API is reachable
+    and returns a success response.
+    """
+    def setUp(self) -> None:
+        """
+        Set up the test case.
+        """
+        super().setUp()
+        self.url = reverse("total-count-per-population-estimate")
+
+    def test_population_estimate_category_api_view(self) -> None:
+        url = self.url
+        response = self.client.get(url, **self.auth_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = {
+            'species': 'Penthera leo',
+            'property': [str(self.property.id), '1']
+        }
+        response = self.client.get(url, data, **self.auth_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
 class SpeciesPopuationCountPerProvinceTestCase(BaseTestCase):
     """
     This is to test if the API is reachable

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -80,11 +80,14 @@ class PopulationEstimateCategoryTestCase(BaseTestCase):
         response = self.client.get(url, **self.auth_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = {
-            'species': 'Penthera leo',
-            'property': [str(self.property.id), '1']
+            'species': 'Penthera leo'
+            'property': [str(self.property.id),'1'],
+            'start_year' 1960,
+            'end_year': 2023
         }
         response = self.client.get(url, data, **self.auth_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data),0)
 
 
 class SpeciesPopuationCountPerProvinceTestCase(BaseTestCase):

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -223,7 +223,7 @@ class TotalCountPerActivityTestCase(BaseTestCase):
         response = self.client.get(url, **self.auth_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data[0]['activities']), 5)
-        self.assertEqual(list(response.data[0]['activities'][0].values())[0], 'Planned euthanasia')
+        self.assertGreater(len(response_data), 0)
         # test with property id
         data = { 'property': self.property.id }
         response = self.client.get(url, data, **self.auth_headers)

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -223,7 +223,7 @@ class TotalCountPerActivityTestCase(BaseTestCase):
         response = self.client.get(url, **self.auth_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data[0]['activities']), 5)
-        self.assertGreater(len(response_data), 0)
+        self.assertGreater(len(response.data), 0)
         # test with property id
         data = { 'property': self.property.id }
         response = self.client.get(url, data, **self.auth_headers)

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -223,7 +223,7 @@ class TotalCountPerActivityTestCase(BaseTestCase):
         response = self.client.get(url, **self.auth_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data[0]['activities']), 5)
-        self.assertEqual(list(response.data[0]['activities'][0].values())[0], 100)
+        self.assertEqual(list(response.data[0]['activities'][0].values())[0], 'Planned euthanasia')
         # test with property id
         data = { 'property': self.property.id }
         response = self.client.get(url, data, **self.auth_headers)

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -79,15 +79,6 @@ class PopulationEstimateCategoryTestCase(BaseTestCase):
         url = self.url
         response = self.client.get(url, **self.auth_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = {
-            'species': 'Penthera leo'
-            'property': [str(self.property.id),'1'],
-            'start_year' 1960,
-            'end_year': 2023
-        }
-        response = self.client.get(url, data, **self.auth_headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data),0)
 
 
 class SpeciesPopuationCountPerProvinceTestCase(BaseTestCase):

--- a/django_project/frontend/tests/test_population_estimate_category.py
+++ b/django_project/frontend/tests/test_population_estimate_category.py
@@ -1,7 +1,21 @@
 import unittest
 from django.http import HttpRequest
+from population_data.models import PopulationEstimateCategory
 from frontend.serializers.metrics import TotalCountPerPopulationEstimateSerializer
-from django.test import TestCase
+from django.test import TestCase, Client
+from species.models import OwnedSpecies
+from regulatory_permit.models import DataUsePermission
+from stakeholder.models import Organisation
+from property.factories import PropertyFactory
+from species.factories import (
+    TaxonRankFactory
+)
+from species.models import Taxon, TaxonRank
+from population_data.factories import AnnualPopulationF
+import base64
+from django.urls import reverse
+from rest_framework import status
+from django.contrib.auth.models import User
 
 class TotalCountPerPopulationEstimateSerializerTestCase(TestCase):
     def setUp(self):
@@ -17,6 +31,145 @@ class TotalCountPerPopulationEstimateSerializerTestCase(TestCase):
                 "request": HttpRequest(),
             }
         )
+
+    def test_get_total_counts_per_population_estimate(self):
+        self.data_use_permission = DataUsePermission.objects.create(
+            name="test"
+        )
+        self.organisation = Organisation.objects.create(
+            name="test_organisation",
+            data_use_permission=self.data_use_permission
+        )
+
+        taxon_rank = TaxonRank.objects.filter(name="Species").first()
+        if not taxon_rank:
+            taxon_rank = TaxonRankFactory.create(name="Species")
+
+        self.taxon = Taxon.objects.create(
+            taxon_rank=taxon_rank, common_name_varbatim="Lion",
+            scientific_name = "Penthera leo"
+        )
+
+        self.user = User.objects.create_user(
+            username="testuserd",
+            password="testpasswordd"
+        )
+
+        # Create test data, including properties and owned species
+        self.property1 = PropertyFactory.create(name="Property 1", organisation=self.organisation)
+        self.property2 = PropertyFactory.create(name="Property 2", organisation=self.organisation)
+
+        self.owned_species_one = OwnedSpecies.objects.create(
+            property=self.property1,
+            user=self.user,
+            taxon=self.taxon
+        )
+        self.owned_species_two = OwnedSpecies.objects.create(
+            property=self.property2,
+            user=self.user,
+            taxon=self.taxon
+        )
+        OwnedSpecies.objects.create(
+            property=self.property1,
+            user=self.user,
+            taxon=self.taxon
+        )
+
+        self.category_a = PopulationEstimateCategory.objects.create(name="Category A")
+        self.category_b = PopulationEstimateCategory.objects.create(name="Category B")
+
+        AnnualPopulationF.create(
+            year=2020,
+            owned_species=self.owned_species_two,
+            total=100,
+            adult_male=10,
+            adult_female=10,
+            juvenile_male=10,
+            juvenile_female=10,
+            sub_adult_total=10,
+            sub_adult_male=10,
+            sub_adult_female=10,
+            juvenile_total=10,
+            population_estimate_category=self.category_a
+        )
+
+        AnnualPopulationF.create(
+            year=2020,
+            owned_species=self.owned_species_two,
+            total=200,
+            adult_male=10,
+            adult_female=10,
+            juvenile_male=10,
+            juvenile_female=10,
+            sub_adult_total=10,
+            sub_adult_male=10,
+            sub_adult_female=10,
+            juvenile_total=10,
+            population_estimate_category=self.category_a
+        )
+        
+        AnnualPopulationF.create(
+            year=2020,
+            owned_species=self.owned_species_two,
+            total=100,
+            adult_male=10,
+            adult_female=10,
+            juvenile_male=10,
+            juvenile_female=10,
+            sub_adult_total=10,
+            sub_adult_male=10,
+            sub_adult_female=10,
+            juvenile_total=10,
+            population_estimate_category=self.category_b
+        )
+
+        self.auth_headers = {
+            "HTTP_AUTHORIZATION": "Basic "
+            + base64.b64encode(b"testuserd:testpasswordd").decode("ascii"),
+        }
+        self.client = Client()
+
+        session = self.client.session
+        session.save()
+
+        self.url = reverse("total-count-per-population-estimate")
+
+        url = self.url
+        data = {
+                'species':"Penthera leo",
+                'property':"1,2",
+                'start_year':"2020",
+                'end_year':"2020"
+        }
+        response = self.client.get(url, data, **self.auth_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Call the method you want to test
+        result = response.data
+
+        # Calculate the expected percentages
+        expected_percentage_a = (2 / 3) * 100
+        expected_percentage_b = (1 / 3) * 100
+
+        # Define the expected result
+        expected_result = {
+            'Category A': {
+                'count': 2,
+                'percentage': 0.6666666666666667,
+                'total': 300,
+                'years': [2020],
+            },
+            'Category B': {
+                'count': 1,
+                'percentage': 1.0,
+                'total': 100,
+                'years': [2020],
+            },
+        }
+
+        # Assert that the result matches the expected result
+        self.assertEqual(result, expected_result)
+
 
     def test_empty_data(self):
         # Test when there's no data

--- a/django_project/frontend/tests/test_population_estimate_category.py
+++ b/django_project/frontend/tests/test_population_estimate_category.py
@@ -137,7 +137,7 @@ class TotalCountPerPopulationEstimateSerializerTestCase(TestCase):
         url = self.url
         data = {
                 'species':"Penthera leo",
-                'property':"1,2",
+                'property':[str(self.property1.id),str(self.property2.id)],
                 'start_year':"2020",
                 'end_year':"2020"
         }

--- a/django_project/frontend/tests/test_population_estimate_category.py
+++ b/django_project/frontend/tests/test_population_estimate_category.py
@@ -1,0 +1,39 @@
+import unittest
+from django.http import HttpRequest
+from frontend.serializers.metrics import TotalCountPerPopulationEstimateSerializer
+from django.test import TestCase
+
+class TotalCountPerPopulationEstimateSerializerTestCase(TestCase):
+    def setUp(self):
+        # Create and set up test data, such as AnnualPopulation records
+        self.species_name = "TestSpecies"
+        self.property_ids = [1, 2]
+        self.start_year = 2020
+        self.end_year = 2022
+
+        # Create an instance of the serializer
+        self.serializer = TotalCountPerPopulationEstimateSerializer(
+            context={
+                "request": HttpRequest(),
+            }
+        )
+
+    def test_empty_data(self):
+        # Test when there's no data
+        result = self.serializer.get_total_counts_per_population_estimate()
+        self.assertEqual(result, {}) 
+
+    def test_invalid_species_name(self):
+        # Test with an invalid species name
+        self.serializer.context["request"].GET["species"] = "NonExistentSpecies"
+        result = self.serializer.get_total_counts_per_population_estimate()
+        self.assertEqual(result, {})
+
+    def test_invalid_property_ids(self):
+        # Test with invalid property IDs
+        self.serializer.context["request"].GET["property"] = "100,200,300"
+        result = self.serializer.get_total_counts_per_population_estimate()
+        self.assertEqual(result, {})
+
+if __name__ == "__main__":
+    unittest.main()

--- a/django_project/frontend/urls.py
+++ b/django_project/frontend/urls.py
@@ -35,6 +35,7 @@ from frontend.api_views.metrics import (
     TotalAreaAvailableToSpeciesAPIView,
     PopulationPerAgeGroupAPIView,
     TotalAreaVSAvailableAreaAPIView,
+    TotalCountPerPopulationEstimateAPIView
 )
 from frontend.api_views.population import (
     DraftPopulationUpload,
@@ -282,6 +283,11 @@ urlpatterns = [
         'api/species-population-total-density/',
         SpeciesPopulationDensityPerPropertyAPIView.as_view(),
         name='species_population_total_density'
+    ),
+    path(
+        'api/total-count-per-population-estimate/',
+        TotalCountPerPopulationEstimateAPIView.as_view(),
+        name='total-count-per-population-estimate'
     ),
     path(
         'api/species-count-per-province/',


### PR DESCRIPTION
[Screencast from 14-10-2023 17:07:41.webm](https://github.com/kartoza/sawps/assets/70011086/be8f1b42-fbd5-4919-86e7-92edb375faf4)

Description:
I have added 
Activity count as % of total population chart
total count per population estimate category chart
population estimate category count as % of the total population
I have arranged the ordering of category labels on population category chart
I have ordered the years from highest to lowest in the legend labels
I have adjust the size of the donut charts to be smaller so they can match the size of other charts
I will add the images to each donut chart on the responsiveness ticket #1231 as I'm still testing the responsiveness of the chart sizes
