### PR TITLE
Charts responsiveness

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
@@ -27,6 +27,7 @@ interface Props {
   endYear: number;
   loading: boolean;
   activityData: ActivityDataItem[];
+  onEmptyDatasets: any
 }
 
 const availableColors = [
@@ -49,6 +50,7 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
   endYear,
   loading,
   activityData,
+  onEmptyDatasets
 }: Props) => {
   // Initialize variables
   const labels: string[] = [];
@@ -59,10 +61,11 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
 
   const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
 
-  if (!selectedSpecies || !activityData || activityData.length === 0) {
-    return null; // Return null if the condition fails
-  }
-
+  useEffect(() => {
+    if (activityData && activityData.length > 0) {
+      onEmptyDatasets(true)
+    }else onEmptyDatasets(false)
+  }, [activityData, selectedSpecies]);
 
   // Iterate through activityData
   activityData.forEach((speciesData: ActivityDataItem) => {

--- a/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
@@ -188,11 +188,11 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
   };
 
   // custom styling for donut charts
-  const chartContainerStyle: React.CSSProperties = {
+   const chartContainerStyle: React.CSSProperties = {
     position: "relative",
     backgroundImage: `url(${backgroundImageUrl})`,
-    backgroundSize: "20% 24%", // width and height of image
-    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+    backgroundSize: "18% 20%", // width and height of image
+    backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
     backgroundRepeat: "no-repeat",
     whiteSpace: "pre-wrap", // Allow text to wrap
   };

--- a/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Doughnut } from "react-chartjs-2";
 import { CategoryScale } from "chart.js";
 import Chart from "chart.js/auto";
@@ -16,6 +16,7 @@ interface ActivityItem {
 }
 
 interface ActivityDataItem {
+  graph_icon: any;
   species_name: string;
   activities: ActivityItem[];
   total: number;
@@ -63,9 +64,12 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
 
   useEffect(() => {
     if (activityData && activityData.length > 0) {
-      onEmptyDatasets(true)
-    }else onEmptyDatasets(false)
-  }, [activityData, selectedSpecies]);
+      const firstItem = activityData[0];
+      if (firstItem.graph_icon) {
+        setBackgroundImageUrl(firstItem.graph_icon);
+      }
+    }
+  }, [activityData, selectedSpecies,startYear,endYear]);
 
   // Iterate through activityData
   activityData.forEach((speciesData: ActivityDataItem) => {
@@ -129,6 +133,10 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
       recentActivitiesMap[activityType].total += total;
     });
   });
+
+   if(labels.length>0){
+    onEmptyDatasets(true)
+  }else onEmptyDatasets(false);
 
   // Create the chartData object
   const chartData = {

--- a/django_project/frontend/src/containers/MainPage/Metrics/AreaAvailableLineChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/AreaAvailableLineChart.tsx
@@ -54,6 +54,15 @@ const AreaAvailableLineChart = (props: any) => {
         }
       }
 
+      let render_chart = true
+      areaDataB.datasets.forEach(dataset => {
+        if (dataset.data.length === 0) {
+          render_chart = false
+        }else render_chart = true
+      });
+
+      if (!render_chart) return null
+
       areaDataB.datasets.forEach(dataset => {
         if (dataset.data.length === 1) {
           dataset.data.unshift(0);

--- a/django_project/frontend/src/containers/MainPage/Metrics/AreaAvailableLineChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/AreaAvailableLineChart.tsx
@@ -38,6 +38,28 @@ const AreaAvailableLineChart = (props: any) => {
         ]
     }
 
+    // incase there is a single label and single value
+    interface AreaDataValueB {
+        labels: number[];
+        datasets: any[];
+      }
+
+    const areaDataB: AreaDataValueB = AreaDataValue
+      
+      if (areaDataB.labels.length === 1) {
+        const year = areaDataB.labels[0];
+        if (!isNaN(year)) {
+          // Modify the data in place by adding the previous year to labels
+          areaDataB.labels = [year - 1, year];
+        }
+      }
+
+      areaDataB.datasets.forEach(dataset => {
+        if (dataset.data.length === 1) {
+          dataset.data.unshift(0);
+        }
+      });
+
     const AreaOptions = {
         tension: 0.5,
         elements: {

--- a/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
@@ -17,6 +17,7 @@ const DensityBarChart = (props: any) => {
         setLoading,
         densityData,
         setDensityData,
+        onEmptyDatasets
     } = props;
 
 
@@ -31,6 +32,9 @@ const DensityBarChart = (props: any) => {
                     setLoading(false);
                     if (response.data) {
                         const filteredData = response.data.filter((item: any) => item.density.density !== null);
+                        if(filteredData.length > 0){
+                            onEmptyDatasets(true)
+                        }else onEmptyDatasets(false)
                         setDensityData(filteredData.length > 0 ? filteredData : []);
                     }
                 })

--- a/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
@@ -31,11 +31,7 @@ const DensityBarChart = (props: any) => {
                 .then((response) => {
                     setLoading(false);
                     if (response.data) {
-                        const filteredData = response.data.filter((item: any) => (
-                            item.density &&
-                            Array.isArray(item.density.density) &&
-                            item.density.density.length > 0
-                        ));
+                        const filteredData = response.data.filter((item: any) => (item.density.density !== null || item.density.density.length !== 0));
                         if(filteredData.length > 0){
                             onEmptyDatasets(true)
                         }else onEmptyDatasets(false)

--- a/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
@@ -31,7 +31,11 @@ const DensityBarChart = (props: any) => {
                 .then((response) => {
                     setLoading(false);
                     if (response.data) {
-                        const filteredData = response.data.filter((item: any) => item.density.density !== null);
+                        const filteredData = response.data.filter((item: any) => (
+                            item.density &&
+                            Array.isArray(item.density.density) &&
+                            item.density.density.length > 0
+                        ));
                         if(filteredData.length > 0){
                             onEmptyDatasets(true)
                         }else onEmptyDatasets(false)

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationCategoryChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationCategoryChart.tsx
@@ -29,6 +29,7 @@ const PopulationCategoryChart = (props: any) => {
       setLoading,
       populationData,
       setPopulationData,
+      onEmptyDatasets
     } = props;
   
     const fetchPopulationCategoryData = () => {
@@ -40,6 +41,11 @@ const PopulationCategoryChart = (props: any) => {
         .then((response) => {
           setLoading(false);
           if (response.data) {
+            if (Object.keys(response.data).length === 0) {
+                onEmptyDatasets(false)
+            } else {
+                onEmptyDatasets(true)
+            }
             setPopulationData(response.data);
           }
         })

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
@@ -34,6 +34,7 @@ const PopulationEstimateCategoryCount = (props: any) => {
     endYear,
     loading,
     setLoading,
+    onEmptyDatasets
   } = props;
   let year: number | null = null;
   const [speciesData, setSpeciesData] = useState([]);
@@ -46,6 +47,11 @@ const PopulationEstimateCategoryCount = (props: any) => {
       )
       .then((response) => {
         if (response.data) {
+          if (Object.keys(response.data).length === 0) {
+              onEmptyDatasets(false)
+          } else {
+              onEmptyDatasets(true)
+          }
           setSpeciesData(response.data);
           setLoading(false);
         }
@@ -110,7 +116,6 @@ const PopulationEstimateCategoryCount = (props: any) => {
       }
     } else {
       chartTitle = "No data available for current filter selections";
-      return null;
     }
   }
 

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
@@ -34,10 +34,23 @@ const PopulationEstimateCategoryCount = (props: any) => {
     endYear,
     loading,
     setLoading,
+    activityData,
     onEmptyDatasets
   } = props;
   let year: number | null = null;
   const [speciesData, setSpeciesData] = useState([]);
+
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (activityData && activityData.length > 0) {
+      const firstItem = activityData[0];
+      if (firstItem.graph_icon) {
+        setBackgroundImageUrl(firstItem.graph_icon);
+      }
+
+    }
+  }, [activityData]);
 
   const fetchPopulationEstimateCategoryCount = () => {
     setLoading(true);
@@ -65,12 +78,6 @@ const PopulationEstimateCategoryCount = (props: any) => {
   useEffect(() => {
     fetchPopulationEstimateCategoryCount();
   }, [propertyId, startYear, endYear, selectedSpecies]);
-  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
-
-  if (!selectedSpecies) {
-    return null; // Return null if the condition fails
-  }
-
 
   // Initialize variables
   const labels: string[] = [];
@@ -156,8 +163,8 @@ const PopulationEstimateCategoryCount = (props: any) => {
   const chartContainerStyle: React.CSSProperties = {
     position: "relative",
     backgroundImage: `url(${backgroundImageUrl})`,
-    backgroundSize: "20% 24%", // width and height of image
-    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+    backgroundSize: "18% 20%", // width and height of image
+    backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
     backgroundRepeat: "no-repeat",
     whiteSpace: "pre-wrap", // Allow text to wrap
   };

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
@@ -34,10 +34,22 @@ const PopulationEstimateAsPercentage = (props: any) => {
     endYear,
     loading,
     setLoading,
+    activityData,
     onEmptyDatasets
   } = props;
 
   const [speciesData, setSpeciesData] = useState<any>({});
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (activityData && activityData.length > 0) {
+      const firstItem = activityData[0];
+      if (firstItem.graph_icon) {
+        setBackgroundImageUrl(firstItem.graph_icon);
+      }
+
+    }
+  }, [activityData]);
 
   const fetchPopulationEstimateCategoryCount = () => {
     setLoading(true);
@@ -65,13 +77,7 @@ const PopulationEstimateAsPercentage = (props: any) => {
   useEffect(() => {
     fetchPopulationEstimateCategoryCount();
   }, [propertyId, startYear, endYear, selectedSpecies]);
-  const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
-
-
-  if (!selectedSpecies) {
-    return null; // Return null if the condition fails
-  }
-
+ 
   // Initialize variables
   const labels: string[] = [];
   const data: number[] = [];
@@ -151,15 +157,15 @@ const PopulationEstimateAsPercentage = (props: any) => {
     },
   };
 
-  // custom styling for donut charts
-  const chartContainerStyle: React.CSSProperties = {
-    position: "relative",
-    backgroundImage: `url(${backgroundImageUrl})`,
-    backgroundSize: "20% 24%", // width and height of image
-    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
-    backgroundRepeat: "no-repeat",
-    whiteSpace: "pre-wrap", // Allow text to wrap
-  };
+ // custom styling for donut charts
+ const chartContainerStyle: React.CSSProperties = {
+  position: "relative",
+  backgroundImage: `url(${backgroundImageUrl})`,
+  backgroundSize: "18% 20%", // width and height of image
+  backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+  backgroundRepeat: "no-repeat",
+  whiteSpace: "pre-wrap", // Allow text to wrap
+};
 
     return (
       <>

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
@@ -34,6 +34,7 @@ const PopulationEstimateAsPercentage = (props: any) => {
     endYear,
     loading,
     setLoading,
+    onEmptyDatasets
   } = props;
 
   const [speciesData, setSpeciesData] = useState<any>({});
@@ -46,6 +47,11 @@ const PopulationEstimateAsPercentage = (props: any) => {
       )
       .then((response) => {
         if (response.data) {
+          if (Object.keys(response.data).length === 0) {
+              onEmptyDatasets(false)
+          } else {
+              onEmptyDatasets(true)
+          }
           setSpeciesData(response.data);
           setLoading(false);
         }
@@ -107,7 +113,6 @@ const PopulationEstimateAsPercentage = (props: any) => {
     chartTitle = "Please select a species for the chart to show available data";
   } else if (Object.keys(speciesData).length === 0) {
     chartTitle = "No data available for current filter selections";
-    return null;
   }
 
   const options = {

--- a/django_project/frontend/src/containers/MainPage/Metrics/PropertyAvailable.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PropertyAvailable.tsx
@@ -28,10 +28,11 @@ interface PropertyAvailableBarChartProps {
     endYear: number;
     loading: boolean;
     setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+    onEmptyDatasets: any;
 }
 
 const PropertyAvailableBarChart: React.FC<PropertyAvailableBarChartProps> = (props) => {
-    const { selectedSpecies, propertyId, startYear, endYear, loading, setLoading } = props;
+    const { selectedSpecies, propertyId, startYear, endYear, loading, setLoading, onEmptyDatasets } = props;
     const [propertyAreaAvailableData, setPropertyAreaAvailableData] = useState<PropertyAreaAvailableData[]>([]);
     const [ renderChart, setRenderChart] = useState(false);
 
@@ -55,6 +56,9 @@ const PropertyAvailableBarChart: React.FC<PropertyAvailableBarChartProps> = (pro
             .then((response) => {
                 setLoading(false);
                 if (response.data) {
+                     if(response.data.length > 0){
+                    onEmptyDatasets(true)
+                  }else onEmptyDatasets(false)
                     setPropertyAreaAvailableData(response.data);
                 }
             })

--- a/django_project/frontend/src/containers/MainPage/Metrics/PropertyType.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PropertyType.tsx
@@ -28,7 +28,7 @@ const colors = [
 const FETCH_SPECIES_DENSITY = '/api/total-area-per-property-type/';
 
 const PropertyTypeBarChart = (props: any) => {
-  const { selectedSpecies, propertyId, startYear, endYear, loading, setLoading } = props;
+  const { selectedSpecies, propertyId, startYear, endYear, loading, setLoading, onEmptyDatasets } = props;
   const [propertyTypeData, setPropertyTypeData] = useState<PropertyTypeData[]>([]);
   const labels: string[] = [];
   const legend_labels: string[] = [];
@@ -42,6 +42,11 @@ const PropertyTypeBarChart = (props: any) => {
       .then((response) => {
         setLoading(false);
         if (response.data) {
+          if(response.data.length > 0){
+            onEmptyDatasets(true)
+          }else {
+            onEmptyDatasets(false)
+          }
           const uniquePropertyTypes: Record<string, number> = {};
           const uniqueColors: Record<string, string> = {};
   

--- a/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
@@ -52,7 +52,8 @@ const SpeciesCountAsPercentage = (props: any) => {
     endYear,
     loading,
     setLoading,
-    activityData
+    activityData,
+    onEmptyDatasets
   } = props;
   const [speciesData, setSpeciesData] = useState<SpeciesDataItem[]>([]);
   const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
@@ -65,6 +66,20 @@ const SpeciesCountAsPercentage = (props: any) => {
       )
       .then((response) => {
         if (response.data) {
+          if(response.data.length > 0){
+            const data = response.data; 
+            
+            data.forEach((item: { year: null; province: any; species: any; }) => {
+                if (item.year === null) {
+                    console.log(`Year is null for province: ${item.province}, species: ${item.species}`);
+                    onEmptyDatasets(false)
+                }
+                if(startYear === item.year || endYear === item.year){
+                  onEmptyDatasets(true)
+                }
+            });
+            
+          }else onEmptyDatasets(false)
           setSpeciesData(response.data);
           setLoading(false);
         }

--- a/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
@@ -70,8 +70,8 @@ const SpeciesCountAsPercentage = (props: any) => {
             const data = response.data; 
             
             data.forEach((item: { year: null; province: any; species: any; }) => {
-                if (item.year === null) {
-                   onEmptyDatasets(false)
+                if (item.year === null || item.year !== endYear || item.year !== startYear) {
+                    onEmptyDatasets(false)
                 }
                 if(startYear === item.year || endYear === item.year){
                   onEmptyDatasets(true)

--- a/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
@@ -146,11 +146,11 @@ const SpeciesCountAsPercentage = (props: any) => {
 
   
   // custom styling for donut charts
-  const chartContainerStyle: React.CSSProperties = {
+   const chartContainerStyle: React.CSSProperties = {
     position: "relative",
     backgroundImage: `url(${backgroundImageUrl})`,
-    backgroundSize: "20% 24%", // width and height of image
-    backgroundPosition: "19% 57%", //horizontal and vertical position respectively
+    backgroundSize: "18% 20%", // width and height of image
+    backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
     backgroundRepeat: "no-repeat",
     whiteSpace: "pre-wrap", // Allow text to wrap
   };

--- a/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
@@ -71,8 +71,7 @@ const SpeciesCountAsPercentage = (props: any) => {
             
             data.forEach((item: { year: null; province: any; species: any; }) => {
                 if (item.year === null) {
-                    console.log(`Year is null for province: ${item.province}, species: ${item.species}`);
-                    onEmptyDatasets(false)
+                   onEmptyDatasets(false)
                 }
                 if(startYear === item.year || endYear === item.year){
                   onEmptyDatasets(true)

--- a/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Doughnut } from "react-chartjs-2";
 import { CategoryScale } from "chart.js";
 import Chart from "chart.js/auto";

--- a/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
@@ -145,13 +145,13 @@ interface SpeciesDataItem {
     };
 
     // custom styling for donut charts
-    const chartContainerStyle: React.CSSProperties = {
-        position: "relative",
-        backgroundImage: `url(${backgroundImageUrl})`,
-        backgroundSize: "20% 24%", // width and height of image
-        backgroundPosition: "19% 57%", //horizontal and vertical position respectively
-        backgroundRepeat: "no-repeat",
-        whiteSpace: "pre-wrap", // Allow text to wrap
+     const chartContainerStyle: React.CSSProperties = {
+      position: "relative",
+      backgroundImage: `url(${backgroundImageUrl})`,
+      backgroundSize: "18% 20%", // width and height of image
+      backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+      backgroundRepeat: "no-repeat",
+      whiteSpace: "pre-wrap", // Allow text to wrap
     };
   
     return (

--- a/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
@@ -36,45 +36,56 @@ interface SpeciesDataItem {
   const TotalCountPerActivity = (props: any) => {
     const {
       selectedSpecies,
+      propertyId,
+      startYear,
+      endYear,
       loading,
-      activityData
+      activityData,
+      onEmptyDatasets
     } = props;
     const [backgroundImageUrl, setBackgroundImageUrl] = useState<string | undefined>(undefined);
 
-    // Add a condition to check if the selectedSpecies and activityData meet your criteria
-    if (!selectedSpecies || !activityData || activityData.length === 0) {
-        return null; // Return null if the condition fails
-    }
+    useEffect(() => {
+      if (activityData && activityData.length > 0) {
+        onEmptyDatasets(true)
+        const firstItem = activityData[0];
+        if (firstItem.graph_icon) {
+          setBackgroundImageUrl(firstItem.graph_icon);
+        }
+      }else onEmptyDatasets(false)
+    }, [propertyId,startYear,endYear,activityData, selectedSpecies]);
   
     // Initialize variables
     const labels: string[] = [];
     const data: number[] = [];
     const uniqueColors: string[] = [];
-    let year: number = 0;
-  
+    let year: number = endYear; // Set the year to the provided startYear
+
     if (activityData && activityData.length > 0) {
       // Iterate through activityData
       activityData.forEach((speciesData: any) => {
         const speciesActivities = speciesData.activities;
-        const latestActivity = speciesActivities.reduce(
-          (maxActivity: any, currentActivity: any) =>
-            currentActivity.year > maxActivity.year ? currentActivity : maxActivity,
-          speciesActivities[0]
+
+        // Find the activity entry that matches the provided startYear
+        const matchingActivity = speciesActivities.find(
+          (activity: any) => activity.year === endYear? activity: null
         );
-  
-        const activityType = latestActivity.activity_type;
-        const total = latestActivity.total;
-        year = latestActivity.year;
-  
-        // Check if the activityType is not in the labels list
-        if (!labels.includes(activityType)) {
+
+        if (matchingActivity) {
+          onEmptyDatasets(true)
+          const activityType = matchingActivity.activity_type;
+          const total = matchingActivity.total;
+
+          // Check if the activityType is not in the labels list
+          if (!labels.includes(activityType)) {
             // Ensure the label is exactly 23 characters long with padding
             const paddedLabel = activityType.padEnd(50, ' '); // Pad with spaces
-          
+
             labels.push(paddedLabel); // Use the padded label
             data.push(total);
             uniqueColors.push(availableColors[labels.length - 1]);
-          }          
+          }
+        } else onEmptyDatasets(false)
       });
     }
   
@@ -98,7 +109,6 @@ interface SpeciesDataItem {
     
     if (!selectedSpecies){
         chartTitle = "Please select a species for the chart to show available data";
-        return null;
     }
   
     const options = {

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -312,31 +312,31 @@ const Metrics = () => {
                                
                             <Grid item xs={12} md={6}></Grid>
                             
-                            {hasEmptyProvinceCountPercentage && (
-                            <Grid item xs={12} md={6} 
-                                style={{ 
-                                    textAlign: 'center', 
-                                    display: 'flex', 
-                                    alignItems: 'center', 
-                                    justifyContent: 'center',
-                                    maxHeight: '370px'
-                                }}
-                            >
-                                <SpeciesCountAsPercentage
-                                    selectedSpecies={selectedSpecies} 
-                                    propertyId={propertyId} 
-                                    startYear={startYear} 
-                                    endYear={endYear}
-                                    loading={loading} 
-                                    setLoading={setLoading}
-                                    activityData={activityData}
-                                    onEmptyDatasets={handleEmptyProvinceCountPercentage}
-                                />
-                            </Grid>
+                            {selectedSpecies && hasEmptyProvinceCountPercentage && (
+                                <Grid item xs={12} md={6} 
+                                    style={{ 
+                                        textAlign: 'center', 
+                                        display: 'flex', 
+                                        alignItems: 'center', 
+                                        justifyContent: 'center',
+                                        maxHeight: '370px'
+                                    }}
+                                >
+                                    <SpeciesCountAsPercentage
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear}
+                                        loading={loading} 
+                                        setLoading={setLoading}
+                                        activityData={activityData}
+                                        onEmptyDatasets={handleEmptyProvinceCountPercentage}
+                                    />
+                                </Grid>
                             )}
 
-                                     
-                            {hasEmptyTotalCountPerActivity && (
+                                    
+                            {selectedSpecies && hasEmptyTotalCountPerActivity && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
@@ -347,7 +347,10 @@ const Metrics = () => {
                                     }}
                                 >
                                     <TotalCountPerActivity
-                                        selectedSpecies={selectedSpecies} 
+                                        selectedSpecies={selectedSpecies}
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear}
                                         loading={loading} 
                                         activityData={totalCoutData}
                                         onEmptyDatasets={handleEmptyTotalCountPerActivity}
@@ -355,8 +358,8 @@ const Metrics = () => {
                                 </Grid>
                             )}
 
-
-                            {hasEmptyTotalCountPerActivityPercentage && (
+                            
+                            {selectedSpecies && hasEmptyTotalCountPerActivityPercentage && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
@@ -378,7 +381,7 @@ const Metrics = () => {
                                 )}
 
                                 
-                            {hasEmptyPopulationEstimateCategoryCount && (
+                            {selectedSpecies && hasEmptyPopulationEstimateCategoryCount && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
@@ -395,12 +398,14 @@ const Metrics = () => {
                                         endYear={endYear}
                                         loading={loading} 
                                         setLoading={setLoading}
+                                        activityData={activityData}
                                         onEmptyDatasets={handleEmptyTopulationEstimateCategoryCount}
                                     />
                                 </Grid>
                                 )}
                            
-                            {hasEmptyPopulationEstimateCategoryCountPercentage && (
+                           
+                            {selectedSpecies && hasEmptyPopulationEstimateCategoryCountPercentage && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
@@ -417,6 +422,7 @@ const Metrics = () => {
                                         endYear={endYear}
                                         loading={loading} 
                                         setLoading={setLoading}
+                                        activityData={activityData}
                                         onEmptyDatasets={handleEmptyPopulationEstimateCategoryCountPercentage}
                                     />
                                 </Grid>

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -53,6 +53,53 @@ const Metrics = () => {
     // Declare errorMessage as a state variable
     const [showChats, setShowCharts] = useState(false);
 
+    const [hasEmptyPopulationTrend, setHasEmptyPopulationTrend] = useState(true);
+    const [hasEmptyPopulationCategory, setHasEmptyPopulationCategory] = useState(true);
+    const [hasEmptyPropertyType, setHasEmptyPropertyType] = useState(true);
+    const [hasEmptyDensity, setHasEmptyDensity] = useState(true);
+    const [hasEmptyProvinceCount, setHasEmptyProvinceCount] = useState(true);
+    const [hasEmptyProvinceCountPercentage, setHasEmptyProvinceCountPercentage] = useState(true);
+    const [hasEmptyTotalCountPerActivity, setHasEmptyTotalCountPerActivity] = useState(true);
+    const [hasEmptyTotalCountPerActivityPercentage, setHasEmptyTotalCountPerActivityPercentage] = useState(true);
+    const [hasEmptyPopulationEstimateCategoryCount, setHasEmptyPopulationEstimateCategoryCount] = useState(true);
+    const [hasEmptyPopulationEstimateCategoryCountPercentage, setHasEmptyhasEmptyPopulationEstimateCategoryCountPercentage] = useState(true);
+    const [hasEmptyPropertyAvailable, setHasEmptyPropertyAvailable] = useState(true);
+
+    // Pass callback functions to each child component for the specific type
+    const handleEmptyPopulationTrend = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyPopulationTrend(isEmpty);
+    };
+    const handleEmptyPopulationCategory = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyPopulationCategory(isEmpty);
+    };
+    const handleEmptyPropertyType = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyPropertyType(isEmpty);
+    };
+    const handleEmptyDensity = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyDensity(isEmpty);
+    };
+    const handleEmptyPropertyAvailable = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyPropertyAvailable(isEmpty);
+    };
+    const handleEmptyProvinceCount = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyProvinceCount(isEmpty);
+    };
+    const handleEmptyProvinceCountPercentage = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyProvinceCountPercentage(isEmpty);
+    };
+    const handleEmptyTotalCountPerActivity = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyTotalCountPerActivity(isEmpty);
+    };
+    const handleEmptyTotalCountPerActivityPercentage = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyTotalCountPerActivityPercentage(isEmpty);
+    };
+    const handleEmptyTopulationEstimateCategoryCount = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyPopulationEstimateCategoryCount(isEmpty);
+    };
+    const handleEmptyPopulationEstimateCategoryCountPercentage = (isEmpty: boolean | ((prevState: boolean) => boolean)) => {
+        setHasEmptyhasEmptyPopulationEstimateCategoryCountPercentage(isEmpty);
+    };
+
     const fetchActivityPercentageData = () => {
         setLoading(true)
         axios.get(`${FETCH_ACTIVITY_PERCENTAGE_URL}?start_year=${startYear}&end_year=${endYear}&species=${selectedSpecies}&property=${propertyId}`).then((response) => {
@@ -118,6 +165,17 @@ const Metrics = () => {
         }else {
             setShowCharts(false);
         }
+        // allow rerender
+        setHasEmptyPopulationTrend(true)
+        setHasEmptyPopulationCategory(true)
+        setHasEmptyPropertyType(true)
+        setHasEmptyDensity(true)
+        setHasEmptyPropertyAvailable(true)
+        setHasEmptyProvinceCountPercentage(true)
+        setHasEmptyTotalCountPerActivity(true)
+        setHasEmptyTotalCountPerActivityPercentage(true)
+        setHasEmptyPopulationEstimateCategoryCount(true)
+        setHasEmptyhasEmptyPopulationEstimateCategoryCountPercentage(true)
 
     }, [propertyId, startYear, endYear, selectedSpecies])
     const handleDownloadPdf = async () => {
@@ -143,56 +201,71 @@ const Metrics = () => {
 
                 {showChats ? (
                         <Grid container spacing={2} ref={contentRef}>
-                            <Grid item xs={12} md={6}>
-                                <PopulationCategoryChart 
-                                selectedSpecies={selectedSpecies} 
-                                propertyId={propertyId} 
-                                startYear={startYear} 
-                                endYear={endYear} 
-                                loading={loading} 
-                                setLoading={setLoading} 
-                                populationData={populationData} 
-                                setPopulationData={setPopulationData} 
-                                />
-                            </Grid>
-                            
-                            <Grid item xs={12} md={6}>
-                                <PropertyTypeBarChart 
-                                    selectedSpecies={selectedSpecies} 
-                                    propertyId={propertyId} 
-                                    startYear={startYear} 
-                                    endYear={endYear} 
-                                    loading={loading} 
-                                    setLoading={setLoading} 
-                                />
-                            </Grid>
+                            {selectedSpecies && hasEmptyPopulationCategory && (
+                                <Grid item xs={12} md={6}>
+                                    <PopulationCategoryChart 
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear} 
+                                        loading={loading} 
+                                        setLoading={setLoading} 
+                                        populationData={populationData} 
+                                        setPopulationData={setPopulationData}
+                                        onEmptyDatasets={handleEmptyPopulationCategory}
+                                    />
+                                </Grid>
+                            )}
 
-                           <Grid item xs={12} md={6}>
-                                <DensityBarChart 
-                                    selectedSpecies={selectedSpecies} 
-                                    propertyId={propertyId} 
-                                    startYear={startYear} 
-                                    endYear={endYear} 
-                                    loading={loading} 
-                                    setLoading={setLoading} 
-                                    densityData={densityData} 
-                                    setDensityData={setDensityData} 
-                                />
-                            </Grid>
+                             {hasEmptyPropertyType && (
+                                <Grid item xs={12} md={6}>
+                                    <PropertyTypeBarChart 
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear} 
+                                        loading={loading} 
+                                        setLoading={setLoading}
+                                        onEmptyDatasets={handleEmptyPropertyType}
+                                    />
+                                </Grid>
+                            )}
 
                             
-                            <Grid item xs={12} md={6}>
-                                <PropertyAvailableBarChart
-                                    selectedSpecies={selectedSpecies}
-                                    propertyId={propertyId}
-                                    startYear={startYear}
-                                    endYear={endYear}
-                                    loading={loading}
-                                    setLoading={setLoading}
-                                />
-                            </Grid>
+                            {selectedSpecies && hasEmptyDensity && (
+                                <Grid item xs={12} md={6}>
+                                    <DensityBarChart 
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear} 
+                                        loading={loading} 
+                                        setLoading={setLoading} 
+                                        densityData={densityData} 
+                                        setDensityData={setDensityData}
+                                        onEmptyDatasets={handleEmptyDensity}
+                                    /> 
+                                </Grid>
+                            )}
 
 
+                            
+                            {selectedSpecies && hasEmptyPropertyAvailable && (
+                                <Grid item xs={12} md={6}>
+                                    <PropertyAvailableBarChart 
+                                        selectedSpecies={selectedSpecies} 
+                                        propertyId={propertyId} 
+                                        startYear={startYear} 
+                                        endYear={endYear} 
+                                        loading={loading} 
+                                        setLoading={setLoading}
+                                        onEmptyDatasets={handleEmptyPropertyAvailable}
+                                    /> 
+                                </Grid>
+                            )}
+
+
+                            
                             {ageGroupData.map((data) => (
                                 <Grid container key={data.id} item xs={12} md={6}>
                                     <AgeGroupBarChart
@@ -204,6 +277,7 @@ const Metrics = () => {
                                     />
                                 </Grid>
                             ))}
+                           
 
                             
                             {areaData.map((data, index) => (
@@ -218,27 +292,34 @@ const Metrics = () => {
                                         null
                                     )}
                                 </Grid>
-                            ))}
+                            ))} 
+                            
 
-                            <Grid item xs={12} md={6}>
-                                <SpeciesCountPerProvinceChart
-                                    selectedSpecies={selectedSpecies} 
-                                    propertyId={propertyId} 
-                                    startYear={startYear} 
-                                    endYear={endYear}
-                                    loading={loading} 
-                                    setLoading={setLoading}
-                                />
-                            </Grid>
-                  
+                            {selectedSpecies && hasEmptyProvinceCount && (
+                                <Grid item xs={12} md={6}>
+                                    <SpeciesCountPerProvinceChart
+                                        selectedSpecies={selectedSpecies}
+                                        propertyId={propertyId}
+                                        startYear={startYear}
+                                        endYear={endYear}
+                                        loading={loading}
+                                        setLoading={setLoading}
+                                        onEmptyDatasets={handleEmptyProvinceCount}
+                                    />
+                                </Grid>
+                            )}
+
+                               
                             <Grid item xs={12} md={6}></Grid>
                             
+                            {hasEmptyProvinceCountPercentage && (
                             <Grid item xs={12} md={6} 
                                 style={{ 
                                     textAlign: 'center', 
                                     display: 'flex', 
                                     alignItems: 'center', 
-                                    justifyContent: 'center' 
+                                    justifyContent: 'center',
+                                    maxHeight: '370px'
                                 }}
                             >
                                 <SpeciesCountAsPercentage
@@ -249,31 +330,40 @@ const Metrics = () => {
                                     loading={loading} 
                                     setLoading={setLoading}
                                     activityData={activityData}
+                                    onEmptyDatasets={handleEmptyProvinceCountPercentage}
                                 />
                             </Grid>
+                            )}
 
-                            
+                                     
+                            {hasEmptyTotalCountPerActivity && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
                                         display: 'flex', 
                                         alignItems: 'center', 
-                                        justifyContent: 'center' 
+                                        justifyContent: 'center',
+                                        maxHeight: '370px'
                                     }}
                                 >
                                     <TotalCountPerActivity
                                         selectedSpecies={selectedSpecies} 
                                         loading={loading} 
                                         activityData={totalCoutData}
+                                        onEmptyDatasets={handleEmptyTotalCountPerActivity}
                                     />
                                 </Grid>
+                            )}
 
+
+                            {hasEmptyTotalCountPerActivityPercentage && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
                                         display: 'flex', 
                                         alignItems: 'center', 
-                                        justifyContent: 'center' 
+                                        justifyContent: 'center',
+                                        maxHeight: '370px'
                                     }}
                                 >
                                     <ActivityCountAsPercentage
@@ -282,15 +372,20 @@ const Metrics = () => {
                                         endYear={endYear}
                                         loading={loading} 
                                         activityData={totalCoutData}
+                                        onEmptyDatasets={handleEmptyTotalCountPerActivityPercentage}
                                     />
                                 </Grid>
+                                )}
 
+                                
+                            {hasEmptyPopulationEstimateCategoryCount && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
                                         display: 'flex', 
                                         alignItems: 'center', 
-                                        justifyContent: 'center' 
+                                        justifyContent: 'center',
+                                        maxHeight: '370px'
                                     }}
                                 >
                                     <PopulationEstimateCategoryCount
@@ -300,15 +395,19 @@ const Metrics = () => {
                                         endYear={endYear}
                                         loading={loading} 
                                         setLoading={setLoading}
+                                        onEmptyDatasets={handleEmptyTopulationEstimateCategoryCount}
                                     />
                                 </Grid>
-
+                                )}
+                           
+                            {hasEmptyPopulationEstimateCategoryCountPercentage && (
                                 <Grid item xs={12} md={6}
                                     style={{ 
                                         textAlign: 'center', 
                                         display: 'flex', 
                                         alignItems: 'center', 
-                                        justifyContent: 'center' 
+                                        justifyContent: 'center',
+                                        maxHeight: '370px'
                                     }}
                                 >
                                     <PopulationEstimateAsPercentage
@@ -318,9 +417,10 @@ const Metrics = () => {
                                         endYear={endYear}
                                         loading={loading} 
                                         setLoading={setLoading}
+                                        onEmptyDatasets={handleEmptyPopulationEstimateCategoryCountPercentage}
                                     />
                                 </Grid>
-
+                            )}
 
                     </Grid>
                 ): (


### PR DESCRIPTION
[Screencast from 17-10-2023 03:10:42.webm](https://github.com/kartoza/sawps/assets/70011086/d7d3b397-f380-46af-9746-a2684a45e664)

Description:
I have set a maximum height on the donut chart grids ,this should prevent them from being too large 
I have added a background image to each donut chart with the appropriate dimensions
All the donut charts are responsive to the end year filter as they fetch data per year
If a chart has empty data it will not be rendered. Only charts with data will be shown 
when a property is selected charts that do not require specie selection will be rendered
when a specie is selected the charts with available data for the specific filter selections will be shown