### PR TITLE
Change the order of all the charts bars

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
@@ -31,11 +31,17 @@ const DensityBarChart = (props: any) => {
                 .then((response) => {
                     setLoading(false);
                     if (response.data) {
-                        const filteredData = response.data.filter((item: any) => (item.density.density !== null || item.density.density.length !== 0));
+                        // Filter out objects with non-null density
+                        const filteredData = response.data.filter((item: { density: any[]; }) => {
+                            const hasNonNullDensity = item.density.some((densityItem) => densityItem.density !== null);
+                            return hasNonNullDensity;
+                        });
+                        
                         if(filteredData.length > 0){
                             onEmptyDatasets(true)
+                            setDensityData(filteredData);
                         }else onEmptyDatasets(false)
-                        setDensityData(filteredData.length > 0 ? filteredData : []);
+                        
                     }
                 })
                 .catch((error) => {

--- a/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/DensityBarChart.tsx
@@ -123,31 +123,30 @@ const DensityBarChart = (props: any) => {
     const datasets = uniqueYears.map((year: any, index: number) => {
         const backgroundColor = colors[index % colors.length];
         const data = filteredArray.map((each: any) => {
-            // Check if the density array exists, is an array, and has at least one item
-            if (each.density && Array.isArray(each.density) && each.density.length > 0) {
-                // Find the density data object with the matching year, if it exists
-                const densityItem = each.density.find((densityDataItem: any) => densityDataItem.year === year);
-                if (densityItem) {
-                    // Access the density value from the found density data object
-                    return densityItem.density;
-                }
+        // Check if the density array exists, is an array, and has at least one item
+        if (each.density && Array.isArray(each.density) && each.density.length > 0) {
+            // Find the density data object with the matching year, if it exists
+            const densityItem = each.density.find((densityDataItem: any) => densityDataItem.year === year);
+            if (densityItem) {
+            // Access the density value from the found density data object
+            return densityItem.density;
             }
-            return null; // Return null if density data is missing or invalid for the given year
+        }
+        return null; // Return null if density data is missing or invalid for the given year
         });
-
-
+    
         if (data.some((value: any) => value !== null)) {
-            // Create the dataset
-            return {
-              label: `${year}`,
-              data: data,
-              backgroundColor: backgroundColor,
-            };
-          }
-          
-
-        
-    });
+        // Create the dataset
+        return {
+            label: `${year}`,
+            data: data,
+            backgroundColor: backgroundColor,
+        };
+        }
+    }).filter(dataset => dataset); // Remove any null datasets
+    
+    // Reverse the order of datasets
+    datasets.reverse();
 
 
 

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationCategoryChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationCategoryChart.tsx
@@ -122,14 +122,15 @@ const PopulationCategoryChart = (props: any) => {
 
     labels.sort(customSort);
 
-    // Sort datasets in descending order
-    newDatasets.sort((a, b) => parseInt(b.label) - parseInt(a.label));
+    // Sort datasets in ascending order (lowest year first)
+    newDatasets.sort((b, a) => parseInt(a.label) - parseInt(b.label));
 
-
+    // Reverse the order of datasets
+    newDatasets.reverse();
 
     const data = {
         labels: labels,
-        datasets: newDatasets
+        datasets: newDatasets,
     };
 
   const options = {

--- a/django_project/frontend/src/containers/MainPage/Metrics/PropertyAvailable.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PropertyAvailable.tsx
@@ -161,7 +161,7 @@ const PropertyAvailableBarChart: React.FC<PropertyAvailableBarChartProps> = (pro
       const areaIndex = group.years.indexOf(year);
       return areaIndex !== -1 ? group.areas[areaIndex] : 0;
     });
-  
+
     return {
       label: year.toString(),
       backgroundColor: backgroundColors[index],
@@ -170,7 +170,10 @@ const PropertyAvailableBarChart: React.FC<PropertyAvailableBarChartProps> = (pro
       data: dataForYear,
     };
   });
-  
+
+  // Reverse the order of datasets
+  datasets.reverse();
+
   const data = {
     labels: labelsB,
     datasets: datasets,


### PR DESCRIPTION
[Screencast from 18-10-2023 20:23:31.webm](https://github.com/kartoza/sawps/assets/70011086/d74db9f2-4ded-4595-b5b4-e5571401d32d)

Description:
I have changed the order of the bars and years on the charts that show years:
population category chart
density chart
total area available to species
total count of species per province
I have also fixed the total count of species per province showing empty chart when no data is available , now it won't be rendered