### PR TITLE
Adjust donut charts

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/ActivityCountAsPercentage.tsx
@@ -112,12 +112,13 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
       // Rule 4: Save unique activity types
       // Check if the activityType is not in the labels list
       if (!labels.includes(activityType)) {
-        // Remove text before "/" to get text after "/"
-        // const modifiedLabel = activityType.split('/').pop(); // Get text after "/"
-        const paddedLabel = activityType.padEnd(50, ' '); // Pad with spaces
-          
-        labels.push(paddedLabel); // Use the padded label
-        // labels.push(activityType); // Use modified label or the original if there's no text after "/"
+        let paddedLabel = activityType
+          if (activityType.length > 25) {
+            // Trim the name to 22 characters and add '...' at the end
+            paddedLabel = activityType.substring(0, 22) + '...';
+          }
+
+        labels.push(paddedLabel.padEnd(50, ' ')); // Use the padded label
         data.push(percentage);
         uniqueColors.push(availableColors[labels.length - 1]);
      }
@@ -180,7 +181,7 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
           : `No data available for ${selectedSpecies} current filter selections`,
         align: 'start' as 'start',
         font: {
-          size: 16,
+          size: 20,
           weight: 'bold' as 'bold',
         },
       },
@@ -192,7 +193,7 @@ const ActivityCountAsPercentage: React.FC<Props> = ({
     position: "relative",
     backgroundImage: `url(${backgroundImageUrl})`,
     backgroundSize: "18% 20%", // width and height of image
-    backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+    backgroundPosition: "19.5% 57%", //horizontal and vertical position respectively
     backgroundRepeat: "no-repeat",
     whiteSpace: "pre-wrap", // Allow text to wrap
   };

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategory.tsx
@@ -90,12 +90,15 @@ const PopulationEstimateCategoryCount = (props: any) => {
       const categoryData = speciesData[category];
       const count = categoryData.count;
       year = categoryData.years[0];
+      
+      let paddedLabel = category
 
-      const paddedLabel = category.padEnd(50, ' '); // Pad with spaces
-          
-      labels.push(paddedLabel); // Use the padded label
+      if(category.length > 25){
+        paddedLabel = category.substring(0, 22) + '...';
+      }
 
-      // labels.push(category);
+      labels.push(paddedLabel.padEnd(50, ' ')); // Use the padded label
+
       data.push(count);
       uniqueColors.push(availableColors[labels.length - 1]);
     }
@@ -152,7 +155,7 @@ const PopulationEstimateCategoryCount = (props: any) => {
         text: chartTitle,
         align: 'start' as 'start',
         font: {
-          size: 16,
+          size: 20,
           weight: 'bold' as 'bold',
         },
       },
@@ -164,7 +167,7 @@ const PopulationEstimateCategoryCount = (props: any) => {
     position: "relative",
     backgroundImage: `url(${backgroundImageUrl})`,
     backgroundSize: "18% 20%", // width and height of image
-    backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+    backgroundPosition: "19.5% 57%", //horizontal and vertical position respectively
     backgroundRepeat: "no-repeat",
     whiteSpace: "pre-wrap", // Allow text to wrap
   };

--- a/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PopulationEstimateCategoryAsPercentage.tsx
@@ -91,11 +91,14 @@ const PopulationEstimateAsPercentage = (props: any) => {
       const percentage = categoryData.percentage;
       year = categoryData.years[0];
 
-      const paddedLabel = category.padEnd(50, ' '); // Pad with spaces
-          
-      labels.push(paddedLabel); // Use the padded label
+      let paddedLabel = category;
 
-      // labels.push(category);
+      if (category.length > 25){
+        paddedLabel = category.substring(0, 22) + '...';
+      }
+          
+      labels.push(paddedLabel.padEnd(50, ' ')); // Use the padded label
+
       data.push(percentage);
       uniqueColors.push(availableColors[labels.length - 1]);
     }
@@ -150,7 +153,7 @@ const PopulationEstimateAsPercentage = (props: any) => {
         text: chartTitle,
         align: 'start' as 'start',
         font: {
-          size: 16,
+          size: 20,
           weight: 'bold' as 'bold',
         },
       },
@@ -162,7 +165,7 @@ const PopulationEstimateAsPercentage = (props: any) => {
   position: "relative",
   backgroundImage: `url(${backgroundImageUrl})`,
   backgroundSize: "18% 20%", // width and height of image
-  backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+  backgroundPosition: "19.5% 57%", //horizontal and vertical position respectively
   backgroundRepeat: "no-repeat",
   whiteSpace: "pre-wrap", // Allow text to wrap
 };

--- a/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/SpeciesCountAsPercentage.tsx
@@ -121,8 +121,12 @@ const SpeciesCountAsPercentage = (props: any) => {
   }));
 
   const labels = calculatedPercentageValues.map((item) => {
-    const paddedProvince = item.province.padEnd(50, ' ');
-    return paddedProvince;
+    // Check if the province name is longer than 25 characters
+    if (item.province.length > 25) {
+      // Trim the name to 22 characters and add '...' at the end
+      return item.province.substring(0, 22) + '...';
+    }
+    return item.province.padEnd(50, ' ');
   });
   
   const percentages = calculatedPercentageValues.map((item) => item.percentage);
@@ -150,7 +154,7 @@ const SpeciesCountAsPercentage = (props: any) => {
     position: "relative",
     backgroundImage: `url(${backgroundImageUrl})`,
     backgroundSize: "18% 20%", // width and height of image
-    backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+    backgroundPosition: "19.5% 57%", //horizontal and vertical position respectively
     backgroundRepeat: "no-repeat",
     whiteSpace: "pre-wrap", // Allow text to wrap
   };
@@ -207,7 +211,7 @@ const SpeciesCountAsPercentage = (props: any) => {
         align: 'start' as 'start',
         
         font: {
-          size: 16,
+          size: 20,
           weight: 'bold' as 'bold',
         },
       },

--- a/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
@@ -78,10 +78,13 @@ interface SpeciesDataItem {
 
           // Check if the activityType is not in the labels list
           if (!labels.includes(activityType)) {
-            // Ensure the label is exactly 23 characters long with padding
-            const paddedLabel = activityType.padEnd(50, ' '); // Pad with spaces
+            let paddedLabel = activityType
+            if (activityType.length > 25) {
+              // Trim the name to 22 characters and add '...' at the end
+              paddedLabel = activityType.substring(0, 22) + '...';
+            }
 
-            labels.push(paddedLabel); // Use the padded label
+            labels.push(paddedLabel.padEnd(50, ' ')); // Use the padded label
             data.push(total);
             uniqueColors.push(availableColors[labels.length - 1]);
           }

--- a/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/TotalCountPerActivity.tsx
@@ -140,7 +140,7 @@ interface SpeciesDataItem {
           text: chartTitle,
           align: 'start' as 'start',
           font: {
-            size: 16,
+            size: 20,
             weight: 'bold' as 'bold',
           },
         },
@@ -152,7 +152,7 @@ interface SpeciesDataItem {
         position: "relative",
         backgroundImage: `url(${backgroundImageUrl})`,
         backgroundSize: "18% 20%", // width and height of image
-        backgroundPosition: "19.6% 57%", //horizontal and vertical position respectively
+        backgroundPosition: "19.5% 57%", //horizontal and vertical position respectively
         backgroundRepeat: "no-repeat",
         whiteSpace: "pre-wrap", // Allow text to wrap
     };

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -335,7 +335,7 @@ const Metrics = () => {
                                         display: 'flex', 
                                         alignItems: 'center', 
                                         justifyContent: 'center',
-                                        maxHeight: '370px'
+                                        maxHeight: '380px'
                                     }}
                                 >
                                     <SpeciesCountAsPercentage
@@ -359,7 +359,7 @@ const Metrics = () => {
                                         display: 'flex', 
                                         alignItems: 'center', 
                                         justifyContent: 'center',
-                                        maxHeight: '370px'
+                                        maxHeight: '380px'
                                     }}
                                 >
                                     <TotalCountPerActivity
@@ -382,7 +382,7 @@ const Metrics = () => {
                                         display: 'flex', 
                                         alignItems: 'center', 
                                         justifyContent: 'center',
-                                        maxHeight: '370px'
+                                        maxHeight: '380px'
                                     }}
                                 >
                                     <ActivityCountAsPercentage
@@ -404,7 +404,7 @@ const Metrics = () => {
                                         display: 'flex', 
                                         alignItems: 'center', 
                                         justifyContent: 'center',
-                                        maxHeight: '370px'
+                                        maxHeight: '380px'
                                     }}
                                 >
                                     <PopulationEstimateCategoryCount
@@ -428,7 +428,7 @@ const Metrics = () => {
                                         display: 'flex', 
                                         alignItems: 'center', 
                                         justifyContent: 'center',
-                                        maxHeight: '370px'
+                                        maxHeight: '380px'
                                     }}
                                 >
                                     <PopulationEstimateAsPercentage


### PR DESCRIPTION
![Screenshot from 2023-10-20 22-52-21](https://github.com/kartoza/sawps/assets/70011086/b67444e8-0187-45df-b6c5-8a02273f2b9c)

I have slightly increased the size of the donut charts 
correctly positioned the image on the center of the donut 
and for legend labels with text thats too long it will trim the label and add '...' showing the label goes on