### PR TITLE
feature/1342-1433: Fix Organisation, Property, and Activity count discrepancy

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Data/Topper.tsx
+++ b/django_project/frontend/src/containers/MainPage/Data/Topper.tsx
@@ -24,9 +24,9 @@ const Topper = () => {
       (state: RootState) => state.SpeciesFilter.activityName
     ).split(',').join(', ')
     const organisationName = useAppSelector((state: RootState) => state.SpeciesFilter.organisationName)
-    const organisationCount = organisationName ? organisationName.split(',').length : 0
-    const propertyCount = propertyName ? propertyName.split(',').length : 0
-    const activityCount = activityId !== '' ? activityId.split(',').length : 0
+    const organisationCount = useAppSelector((state: RootState) => state.SpeciesFilter.organisationCount)
+    const propertyCount = useAppSelector((state: RootState) => state.SpeciesFilter.propertyCount)
+    const activityCount = useAppSelector((state: RootState) => state.SpeciesFilter.activityCount)
     const today = new Date()
     const todayDate = String(today.getDate()).padStart(2, '0')
     const todayMonth = String(today.getMonth() + 1).padStart(2, '0')

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -27,7 +27,10 @@ import {
     selectedPropertyName,
     setStartYear,
     toggleSpecies,
-    selectedActivityName
+    selectedActivityName,
+    setOrganisationCount,
+    setPropertyCount,
+    setActivityCount
 } from '../../../reducers/SpeciesFilter';
 import './index.scss';
 import {MapEvents} from '../../../models/Map';
@@ -363,6 +366,7 @@ function Filter(props: any) {
               propertyObj => selectedProperty.includes(propertyObj.id)
             ).map(propertyObj => propertyObj.name)
             dispatch(selectedPropertyName(selectedPropertyNames.length > 0 ? selectedPropertyNames.join(', ') : ''));
+            dispatch(setPropertyCount(selectedProperty.length));
         }
     }, [selectedProperty])
 
@@ -385,6 +389,7 @@ function Filter(props: any) {
               organisationObj => selectedOrganisation.includes(organisationObj.id)
             ).map(organisationObj => organisationObj.name)
             dispatch(selectedOrganisationName(selectedOrganisationNames.length > 0 ? selectedOrganisationNames.join(', ') : ''));
+            dispatch(setOrganisationCount(selectedOrganisation.length));
         }
     }, [selectedOrganisation])
 
@@ -395,6 +400,7 @@ function Filter(props: any) {
               activityObj => selectedActivity.includes(activityObj.id)
             ).map(activityObj => activityObj.name)
             dispatch(selectedActivityName(selectedActivityNames.length > 0 ? selectedActivityNames.join(',') : ''));
+            dispatch(setActivityCount(selectedActivity.length));
         }
     }, [selectedActivity])
 

--- a/django_project/frontend/src/reducers/SpeciesFilter.ts
+++ b/django_project/frontend/src/reducers/SpeciesFilter.ts
@@ -16,6 +16,9 @@ export interface SpeciesFilterInterface {
   activityName: string,
   propertyName:string;
   organisationName:string;
+  propertyCount:number;
+  organisationCount:number;
+  activityCount:number;
 }
 
 const initialState: SpeciesFilterInterface = {
@@ -32,7 +35,10 @@ const initialState: SpeciesFilterInterface = {
   spatialFilterValues: "",
   activityName: "",
   propertyName:"",
-  organisationName: ""
+  organisationName: "",
+  propertyCount: 0,
+  organisationCount: 0,
+  activityCount: 0
 };
 
 export const SpeciesFilterSlice = createSlice({
@@ -103,6 +109,15 @@ export const SpeciesFilterSlice = createSlice({
     },
     selectedOrganisationName: (state, action: PayloadAction<string>) => {
       state.organisationName = action.payload;
+    },
+    setPropertyCount: (state, action: PayloadAction<number>) => {
+      state.propertyCount = action.payload;
+    },
+    setOrganisationCount: (state, action: PayloadAction<number>) => {
+      state.organisationCount = action.payload;
+    },
+    setActivityCount: (state, action: PayloadAction<number>) => {
+      state.activityCount = action.payload;
     }
   },
 });
@@ -121,7 +136,10 @@ export const {
   setSpatialFilterValues,
   selectedActivityName,
   selectedPropertyName,
-  selectedOrganisationName
+  selectedOrganisationName,
+  setPropertyCount,
+  setOrganisationCount,
+  setActivityCount
 } = SpeciesFilterSlice.actions;
 
 export default SpeciesFilterSlice.reducer;


### PR DESCRIPTION
This is PR for #1342 #1433 
I tested by updating some organisations and properties into having comma. Now the count between filters and topper are equal.
![2023-10-27_14-12](https://github.com/kartoza/sawps/assets/7352963/bfa7afc8-2ba8-4162-b6b6-f91a485f0328)
