### PR TITLE
Fix styling frontend page trend charts

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Trends/index.scss
+++ b/django_project/frontend/src/containers/MainPage/Trends/index.scss
@@ -1,4 +1,4 @@
-.species-card-container {
+.species-card-container-trends {
   color: #000000;
 
   .species-card-text {

--- a/django_project/frontend/src/containers/MainPage/Trends/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Trends/index.tsx
@@ -61,7 +61,7 @@ const Trends = () => {
           >
             {selectedSpecies && rerender && (
               <Grid item xs={12} md={6}>
-                <div className='species-card-container' data-testid='species-card-container'>
+                <div className='species-card-container-trends' data-testid='species-card-container-trends'>
                   <div className='species-card-image-container'>
                     <img
                       src={taxonDetail.graph_icon ? taxonDetail.graph_icon : '/static/images/default-species.png'}


### PR DESCRIPTION
The same className from trends component is overwriting the size of trend charts in landing page.
Before:
![Screenshot_4736](https://github.com/kartoza/sawps/assets/5819076/952ce44e-b559-4e21-9da8-161a3483aabc)

After fix:
![Screenshot_4737](https://github.com/kartoza/sawps/assets/5819076/04a99b21-f6dc-45d3-89b8-e8d9771d864b)
