### PR TITLE
Fix find property by coordinate for superuser

### DIFF
--- a/django_project/frontend/tests/test_map.py
+++ b/django_project/frontend/tests/test_map.py
@@ -279,6 +279,16 @@ class TestMapAPIViews(TestCase):
         # should find 0
         response = view(request)
         self.assertEqual(response.status_code, 404)
+        # superuser should be able to access it
+        request = self.factory.get(
+            reverse('find-property') + (
+                f'/?lat={lat}&lng={lng}'
+            ),
+            organisation_id=self.organisation_1.id
+        )
+        request.user = self.superuser
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
 
     @mock.patch('frontend.api_views.map.cache.get')
     def test_map_authenticate(self, mocked_cache):


### PR DESCRIPTION
This is to fix superuser not able to see the property information when clicking on properties in the map. 

![image](https://github.com/kartoza/sawps/assets/5819076/7124be34-d3a5-45cd-ac55-debdf4f3c63e)
