### PR TITLE
Fix min count for properties population layer

### DIFF
--- a/django_project/frontend/utils/map.py
+++ b/django_project/frontend/utils/map.py
@@ -464,8 +464,6 @@ def get_count_summary_of_population(
     :return: Tuple[int, int]: A tuple of (Min, Max) population count
     """
     where_sql = ''
-    if not is_province_layer:
-        where_sql = 'WHERE count > 0'
     sql = (
         """
         select min(count), max(count) from "{view_name}"


### PR DESCRIPTION
This is to fix legends for properties choropleth layer that does not start with 0 when there is property without any data. Discussion for this issue is from [this comment](https://github.com/kartoza/sawps/pull/1519#issuecomment-1794465210).
cc: @LunaAsefaw 
![Screenshot_4757](https://github.com/kartoza/sawps/assets/5819076/790bf930-93b9-4bb6-a536-5fadacd76e84)
