### PR TITLE
fix color for trend chart in landing page

### DIFF
--- a/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/SpeciesChart/index.tsx
+++ b/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/SpeciesChart/index.tsx
@@ -111,11 +111,27 @@ const SpeciesChart:FC<ISpeciesChartProps> = (props)=>{
         maintainAspectRatio: true,
         aspectRatio: 1.5,
         scales: {
-            y: {grace:50},
+            y: {
+                grace:50,
+                ticks: {
+                    color: "#fff"
+                }
+            },
+            x: {
+                ticks: {
+                    color: "#fff"
+                }
+            }
         },
         plugins: {
             legend: {
                 labels: {
+                    color: "#fff",
+                    font: {
+                        family: "'Inter', sans-serif",
+                        size: 12,
+                        lineHeight: 18
+                    },
                     filter: function(item: LegendItem, chart: ChartJS) {
                         if (item.text && typeof item.text === 'string') {
                             return !item.text.includes('_ci');


### PR DESCRIPTION
This is for #1413. Fix color for x/y axis and legend.
Preview:
![Screenshot_4759](https://github.com/kartoza/sawps/assets/5819076/3c064fc5-7a40-4bba-b19c-d4db06350860)
