### PR TITLE
Feature/1574 year filter

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Data/Topper.tsx
+++ b/django_project/frontend/src/containers/MainPage/Data/Topper.tsx
@@ -19,6 +19,8 @@ interface TopperProps {
 
 
 const Topper = () => {
+    const [tab, setTab] = useState<string>('')
+    const startYearDisabled = ['map', 'charts'].includes(tab);
     const selectedSpecies = useAppSelector((state: RootState) => state.SpeciesFilter.selectedSpecies)
     const startYear = useAppSelector((state: RootState) => state.SpeciesFilter.startYear)
     const endYear = useAppSelector((state: RootState) => state.SpeciesFilter.endYear)
@@ -38,6 +40,11 @@ const Topper = () => {
     const todayStr = [todayDate, todayMonth, todayYear].join('/')
     const {data: taxonDetail, isLoading: isTaxonDetailLoading, isSuccess} = useGetTaxonDetailQuery(selectedSpecies)
     const [speciesIcon, setSpeciesIcon] = useState("/static/images/default-species-topper.svg")
+
+    useEffect(() => {
+        const pathname = window.location.pathname.replace(/\//g, '');
+        setTab(pathname)
+    }, [window.location.pathname])
 
 
     useEffect(() => {
@@ -93,7 +100,7 @@ const Topper = () => {
                               <Grid item xs>
                                   <Box><img src="/static/images/clock-topper.svg" alt='Clock image'/></Box>
                                   <Box className={'text-content'}>
-                                      <b>{startYear} - {endYear}</b>
+                                      <b>{startYearDisabled ? `${endYear} - ${endYear}` : `${startYear} - ${endYear}`}</b>
                                   </Box>
                               </Grid>
                               <Grid item xs>

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -35,7 +35,8 @@ const Metrics = () => {
     const selectedSpecies = useAppSelector((state: RootState) => state.SpeciesFilter.selectedSpecies)
     const activityId = useAppSelector((state: RootState) => state.SpeciesFilter.activityId)
     const propertyId = useAppSelector((state: RootState) => state.SpeciesFilter.propertyId)
-    const startYear = useAppSelector((state: RootState) => state.SpeciesFilter.startYear)
+    // start year on charts is taken from Filter's endYear.
+    const startYear = useAppSelector((state: RootState) => state.SpeciesFilter.endYear)
     const endYear = useAppSelector((state: RootState) => state.SpeciesFilter.endYear)
     const [loading, setLoading] = useState(false)
     const [activityData, setActivityData] = useState([])

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -63,6 +63,7 @@ function Filter(props: any) {
     const [selectedInfo, setSelectedInfo] = useState<string[]>(['Species report']);
     const [selectedOrganisation, setSelectedOrganisation] = useState([]);
     const [tab, setTab] = useState<string>('')
+    const startYearDisabled = ['map', 'charts'].includes(tab);
     const [searchSpeciesList, setSearchSpeciesList] = useState([])
     const [allowPropertiesSelection, setPropertiesSelection] = useState(false)
     const [allowOrganisationSelection, setOrganisationSelection] = useState(false)
@@ -188,8 +189,8 @@ function Filter(props: any) {
 
     const handleChange = (event: any, newValue: number | number[]) => {
         if (Array.isArray(newValue)) {
-            setLocalStartYear((newValue[0]))
-            dispatch(setStartYear(newValue[0]));
+            setLocalStartYear((startYearDisabled? localStartYear : newValue[0]))
+            dispatch(setStartYear(startYearDisabled? localStartYear : newValue[0]));
             setLocalEndYear((newValue[1]))
             dispatch(setEndYear(newValue[1]));
         }
@@ -547,6 +548,7 @@ function Filter(props: any) {
                                     type="number" size='small' value={localStartYear}
                                     onChange={(e: any) => handleStartYearChange(e.target.value)}
                                     className={isStartYearValid ? '': 'yearFilter-red'}
+                                    disabled={startYearDisabled}
                                   />
                             </Tooltip>
                             <Typography className='formtext'>From</Typography>


### PR DESCRIPTION
This is PR for #1574 
- [x] Start year (left part), both slider and input, is disabled in map and charts
- [x] Charts will only use end year (right part) to get and show data

**Year filter screnrecord**
[Kazam_screencast_00051.webm](https://github.com/kartoza/sawps/assets/7352963/8b9ecef8-cdcb-48bf-8b58-d3c08423475e)

**Charts topper**
![charts-topper](https://github.com/kartoza/sawps/assets/7352963/9e8f4ae5-5665-4aea-9cf1-5ec0b6554eff)

**Report topper**
![report-topper](https://github.com/kartoza/sawps/assets/7352963/a4e51495-6192-4f7f-9523-bafb77886e78)

**Chart data only shows data for year in end year**
[Acinonyx jubatus - metrics-1.pdf](https://github.com/kartoza/sawps/files/13303118/Acinonyx.jubatus.-.metrics-1.pdf)
