### PR TITLE
fix properties point layer visibility

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
+++ b/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
@@ -413,7 +413,7 @@ export const drawPropertiesLayer = (showPopulationCount: boolean, mapObj: maplib
             },
             "minzoom": 5,
             "maxzoom": 10
-        }, 'NGI aerial imagery')
+        }, 'erf-highlighted')
     } else {
         // add province layer
         if (provinceCount && provinceCount.length > 0) {
@@ -483,7 +483,7 @@ export const drawPropertiesLayer = (showPopulationCount: boolean, mapObj: maplib
                 "maxzoom": 10
             }
             addLayerToMap('properties', mapObj, _propertiesLayer, 'erf-highlighted')
-            addLayerToMap('properties-points', mapObj, _propertiesPointsLayer, 'NGI aerial imagery')
+            addLayerToMap('properties-points', mapObj, _propertiesPointsLayer, 'erf-highlighted')
         }
     }
     // add label based on maptheme
@@ -505,9 +505,8 @@ export const drawPropertiesLayer = (showPopulationCount: boolean, mapObj: maplib
                 'interpolate',
                 ['linear'],
                 ['zoom'],
-                7, ["literal", [0, -1.25]],
-                10, ["literal", [0, -1]],
-                12, ["literal", [0, 0]]
+                7, ["literal", [0, -1]],
+                10, ["literal", [0, -0.75]],
               ]
             },
             "paint": {
@@ -533,9 +532,8 @@ export const drawPropertiesLayer = (showPopulationCount: boolean, mapObj: maplib
                 'interpolate',
                 ['linear'],
                 ['zoom'],
-                7, ["literal", [0, -1.25]],
-                10, ["literal", [0, -1]],
-                12, ["literal", [0, 0]]
+                7, ["literal", [0, -1]],
+                10, ["literal", [0, -0.75]],
               ]
             },
             "paint": {


### PR DESCRIPTION
This is to fix properties points layer is not visible (see Luna's comment in [here](https://github.com/kartoza/sawps/issues/812#issuecomment-1804682010)

Now we can see the dot points of property:
![Screenshot_4763](https://github.com/kartoza/sawps/assets/5819076/b3a8fff8-f1e0-4942-ade5-b19e07ab9474)
