### PR TITLE
feature/1589: Remove Population Estimate Category Percentage chart

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Data/Topper.tsx
+++ b/django_project/frontend/src/containers/MainPage/Data/Topper.tsx
@@ -100,7 +100,7 @@ const Topper = () => {
                               <Grid item xs>
                                   <Box><img src="/static/images/clock-topper.svg" alt='Clock image'/></Box>
                                   <Box className={'text-content'}>
-                                      <b>{startYearDisabled ? `${endYear} - ${endYear}` : `${startYear} - ${endYear}`}</b>
+                                      <b>{startYearDisabled ? endYear : `${startYear} - ${endYear}`}</b>
                                   </Box>
                               </Grid>
                               <Grid item xs>

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -410,23 +410,6 @@ const Metrics = () => {
                                 </Grid>
                                 )}
 
-
-                            {
-                            constants.canViewPopulationEstimateAsPercentage &&
-                            selectedSpecies && (
-                                <Grid item xs={12} md={12} lg={6}>
-                                    <PopulationEstimateAsPercentage
-                                        selectedSpecies={selectedSpecies}
-                                        propertyId={propertyId}
-                                        startYear={startYear}
-                                        endYear={endYear}
-                                        loading={loading}
-                                        setLoading={setLoading}
-                                        activityData={activityData}
-                                    />
-                                </Grid>
-                            )}
-
                     </Grid>
                         </>
                 ): (


### PR DESCRIPTION
This is PR for #1589 
I remove Population Estimate Category As Percentage as per discussion with @LunaAsefaw . I also changed Charts topper to only show single year, instead of year range.
![Screenshot from 2023-11-13 20-57-06](https://github.com/kartoza/sawps/assets/7352963/8790a085-566c-47ef-8311-4eae953bf09a)
