### PR TITLE
fix main content height - map becomes hidden

### DIFF
--- a/django_project/frontend/src/containers/MainPage/index.scss
+++ b/django_project/frontend/src/containers/MainPage/index.scss
@@ -75,9 +75,8 @@ body {
 }
 
 #right-sidebar-tab {
-    position: absolute;
-    margin-top: 50px;
     width: calc(100vw - 400px);
+    height: calc(100% - 50px);
 }
 
 #toggle-left-sidebar {


### PR DESCRIPTION
Preview for each tab:

- Map
![Screenshot_4774](https://github.com/kartoza/sawps/assets/5819076/e3e59ce3-62e6-4d61-b07a-a672cbafd6a1)

- Reports
![Screenshot_4775](https://github.com/kartoza/sawps/assets/5819076/236809b9-0e68-4485-81be-1b4ff1bcc49d)

- Charts
![Screenshot_4776](https://github.com/kartoza/sawps/assets/5819076/1092b53c-be36-400f-99a4-c70d8f606e2d)
