### PR TITLE
add circle stroke for properties points

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
+++ b/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
@@ -409,7 +409,9 @@ export const drawPropertiesLayer = (showPopulationCount: boolean, mapObj: maplib
             "source-layer": "properties-points",
             "layout": {"visibility": "visible"},
             "paint": {
-                "circle-color": "rgba(255, 82, 82, 0.8)"
+                "circle-color": "rgba(255, 82, 82, 0.8)",
+                "circle-stroke-width": 1,
+                "circle-stroke-color": "rgb(0, 0, 0)"
             },
             "minzoom": 5,
             "maxzoom": 10
@@ -477,7 +479,9 @@ export const drawPropertiesLayer = (showPopulationCount: boolean, mapObj: maplib
                         "stops": getMapPopulationStops(propertiesCount),
                         "base": 1,
                         "default": "rgba(248, 0, 255, 1)"
-                    }
+                    },
+                    "circle-stroke-width": 1,
+                    "circle-stroke-color": "rgb(0, 0, 0)"
                 },
                 "minzoom": 5,
                 "maxzoom": 10


### PR DESCRIPTION
This is to add border color to properties dot point so it will be much visible.

Preview:
![Screenshot_4786](https://github.com/kartoza/sawps/assets/5819076/2c946d1f-868f-406a-9e82-8dfb8c9607cc)

![Screenshot_4788](https://github.com/kartoza/sawps/assets/5819076/8f6d6860-5141-4fef-a5c7-2e097fe71d22)