### PR TITLE
Fix upload popup error

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Property/PropertyInfo.tsx
+++ b/django_project/frontend/src/containers/MainPage/Property/PropertyInfo.tsx
@@ -11,12 +11,15 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
+import IconButton from '@mui/material/IconButton';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import PropertyInterface, {
     PropertyValidation,
     PropertyTypeInterface,
     OpenCloseInterface
 } from '../../../models/Property';
 import { OrganisationInterface } from '../../../models/Stakeholder';
+import AlertMessage from '../../../components/AlertMessage';
 import './index.scss';
 
 interface PropertyInfoInterface {
@@ -39,6 +42,7 @@ export default function PropertyInfo(props: PropertyInfoInterface) {
     const [propertyTypeList, setPropertyTypeList] = useState<PropertyTypeInterface[]>([])
     const [organisationList, setOrganisationList] = useState<OrganisationInterface[]>([])
     const [openCloseList, setOpenCloseList] = useState<OpenCloseInterface[]>([])
+    const [alertMessage, setAlertMessage] = useState<string>('')
 
     const fetchMetadataList = () => {
         setLoading(true)
@@ -75,6 +79,9 @@ export default function PropertyInfo(props: PropertyInfoInterface) {
 
     return (
         <TableContainer component={Paper}>
+            <AlertMessage message={alertMessage} onClose={() => {
+                setAlertMessage('')
+            }} />
             <Table className='PropertyInfoTable' aria-label="property info table" size='small'>
                 <colgroup>
                     <col width="50%" />
@@ -94,6 +101,20 @@ export default function PropertyInfo(props: PropertyInfoInterface) {
                         </TableCell>
                         <TableCell className='TableCellText'>
                             <span>{props.property.short_code ? props.property.short_code : '-'}</span>
+                            <span>
+                                <IconButton
+                                    aria-label="Copy Property Code"
+                                    onClick={() => {
+                                        navigator.clipboard.writeText(props.property.short_code)
+                                        setAlertMessage('Property code is copied to clipboard')
+                                    }}
+                                    edge="end"
+                                    title='Copy Property Code'
+                                    sx={{marginLeft: '10px'}}
+                                >
+                                    <ContentCopyIcon />
+                                </IconButton>
+                            </span>
                         </TableCell>
                     </TableRow>
                     )}

--- a/django_project/frontend/src/containers/MainPage/Upload/SpeciesUploader.tsx
+++ b/django_project/frontend/src/containers/MainPage/Upload/SpeciesUploader.tsx
@@ -145,11 +145,11 @@ export default function Uploader(props: UploaderInterface) {
             setLoading(true)
             setCloseButton('CLOSE')
             setTimeout(() => {
+                setLoading(false)
                 file.remove()
                 let response = JSON.parse(xhr.response)
                 setIsError(true)
                 setAlertMessage(response.detail)
-
             }, 300)
         }
     };

--- a/django_project/frontend/src/containers/MainPage/Upload/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Upload/index.tsx
@@ -33,6 +33,12 @@ import './index.scss';
 const FETCH_PROPERTY_LIST_URL = '/api/property/list/'
 const FETCH_PROPERTY_DETAIL_URL = '/api/property/detail/'
 
+const getPropertyText = (property: PropertyInterface) => {
+    return `${property.name} (${property.short_code})`
+}
+
+
+
 function Upload() {
     const dispatch = useAppDispatch()
     const [loading, setLoading] = useState(false)
@@ -129,13 +135,13 @@ function Upload() {
                                                     if (selected.length === 0 || selected === '0') {
                                                         return <span className='SelectPlaceHolder'>Select Property</span>
                                                     }
-                                        
-                                                    return selected
+                                                    let _selectedProperty = propertyList.find((val) => val.id === parseInt(selected))
+                                                    return _selectedProperty ? getPropertyText(_selectedProperty) : selected
                                                 }}
                                             >
                                                 { propertyList.map((property: PropertyInterface) => {
                                                     return (
-                                                        <MenuItem key={property.id} value={property.id}>{property.name}</MenuItem>
+                                                        <MenuItem key={property.id} value={property.id}>{getPropertyText(property)}</MenuItem>
                                                     )
                                                 })}
                                             </Select>

--- a/django_project/population_data/models.py
+++ b/django_project/population_data/models.py
@@ -43,7 +43,6 @@ class AnnualPopulationAbstract(models.Model):
         is not greater than total.
         """
         if self.adult_male is not None or self.adult_female is not None:
-            print('aaaa')
             adult_male = self.adult_male if self.adult_male else 0
             adult_female = self.adult_female if self.adult_female else 0
             if adult_male + adult_female > self.total:

--- a/django_project/species/tasks/upload_species.py
+++ b/django_project/species/tasks/upload_species.py
@@ -38,6 +38,7 @@ def upload_species_data(upload_session_id):
     upload_session.processed = False
     upload_session.success_notes = None
     upload_session.error_notes = None
+    upload_session.canceled = False
     if upload_session.success_file:
         try_delete_uploaded_file(upload_session.success_file)
         upload_session.success_file = None

--- a/django_project/species/test_api_views.py
+++ b/django_project/species/test_api_views.py
@@ -892,6 +892,7 @@ class TestUploadSpeciesApiView(TestCase):
         upload_session.refresh_from_db()
         self.assertFalse(upload_session.success_file)
         self.assertFalse(upload_session.error_file)
+        self.assertFalse(upload_session.canceled)
 
     def test_overwrite_annual_population(self):
         """Test upload species multiple times to overwrite data."""


### PR DESCRIPTION
This is for #1504 - fix dropzone is disabled after upload is error.
Preview:
 
![chrome_XrakVXSAuI](https://github.com/kartoza/sawps/assets/5819076/cfe70968-eb46-435d-9e47-dfe407a513d3)

Also made improvements:

- Add property short code to dropdown in Data Upload
![chrome_64u7YfveLe](https://github.com/kartoza/sawps/assets/5819076/3ec300fa-eec5-41f3-a75b-f4ee0584105f)

- Add copy to clipboard for property code in info section
![Screenshot_4790](https://github.com/kartoza/sawps/assets/5819076/fdfc28cb-99c0-4346-8712-065c7719261a)

- Reset canceled field when task is being rerun
