### PR TITLE
fix/1621: Fix Chart UI

### DIFF
--- a/django_project/frontend/api_views/metrics.py
+++ b/django_project/frontend/api_views/metrics.py
@@ -437,8 +437,11 @@ class BasePropertyCountAPIView(APIView):
             upper_bound = categories[idx + 1]
 
         if query_field == 'population_density':
-            lower_bound = round(lower_bound, 4)
-            upper_bound = round(upper_bound, 4)
+            lower_bound = round(lower_bound, 2)
+            upper_bound = round(upper_bound, 2)
+        else:
+            lower_bound = round(lower_bound)
+            upper_bound = round(upper_bound)
 
         return lower_bound, upper_bound
 
@@ -449,6 +452,10 @@ class BasePropertyCountAPIView(APIView):
             data,
             n_classes=data.count() if data.count() < 6 else 6
         )
+        if query_field == 'population_density':
+            categories = sorted([round(cat, 2) for cat in categories])
+        else:
+            categories = sorted([round(cat) for cat in categories])
 
         results = []
         for idx, category in enumerate(categories):
@@ -485,7 +492,8 @@ class BasePropertyCountAPIView(APIView):
                             property_type_name_field
                         ].lower().replace(' ', '_')
                     ] = count['count']
-                results.append(result)
+                if counts.exists():
+                    results.append(result)
         return results
 
 

--- a/django_project/frontend/src/containers/MainPage/Metrics/PropertyCountPerCategory.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/PropertyCountPerCategory.tsx
@@ -40,7 +40,7 @@ const PropertyCountPerCategoryChart = (props: any) => {
   const species = propertyData.length > 0 ? propertyData[0].common_name_varbatim : '';
 
   // Define the labels (category) dynamically from propertyData and sort them from highest to lowest
-  const labels = propertyData.map((data: any) => data.category).sort();
+  const labels = propertyData.map((data: any) => data.category);
   
   const fetchPopulationEstimateCategoryCount = () => {
     setLoading(true);
@@ -109,6 +109,7 @@ const PropertyCountPerCategoryChart = (props: any) => {
   }
 
   let data = null;
+  console.debug(labels)
 
   if (labels.length > 0 && datasets.length > 0) {
     data = {
@@ -116,6 +117,16 @@ const PropertyCountPerCategoryChart = (props: any) => {
       datasets: datasets,
     };
   } else return null;
+
+  const options = {
+        scales: {
+            y: {
+              ticks: {
+                  precision: 0
+              },
+            }
+        }
+    }
 
   return (
     <>
@@ -127,6 +138,7 @@ const PropertyCountPerCategoryChart = (props: any) => {
             yLabel={'Count'}
             xLabel={xLabel}
             indexAxis={'x'}
+            options={options}
         />
       ) : (
         <Loading containerStyle={{minHeight: 160}}/>

--- a/django_project/frontend/tests/test_metrics.py
+++ b/django_project/frontend/tests/test_metrics.py
@@ -705,7 +705,7 @@ class TestPropertyCountPerAreaCategory(
             response.json(),
             [
                 {
-                    'category': '198.0 - 200.0',
+                    'category': '198 - 200',
                     self.property.property_type.name.lower().replace(' ', '_'): 1,
                     'common_name_varbatim': self.taxon.common_name_varbatim
                 }
@@ -745,7 +745,7 @@ class TestPropertyCountPerAreaAvailableToSpeciesCategory(
             response.json(),
             [
                 {
-                    'category': '8.0 - 10.0',
+                    'category': '8 - 10',
                     self.property.property_type.name.lower().replace(' ', '_'): 1,
                     'common_name_varbatim': self.taxon.common_name_varbatim
                 }


### PR DESCRIPTION
This is PR for #1621 
- [x] The bars are in ascending order.
- [x] The y-axis will always be an integer so we need it to be on an integer interval (eg 1, 2, 3 ..).
- [x] X-axix of "Number of properties per categories of area (ha)" chart must be rounded to nearest integer. 