### PR TITLE
hide edit action when user is not the data owner

### DIFF
--- a/django_project/frontend/serializers/report.py
+++ b/django_project/frontend/serializers/report.py
@@ -54,13 +54,13 @@ class SpeciesReportSerializer(
     def get_is_editable(self, obj: AnnualPopulation):
         user = self.context.get('user', None)
         managed_organisations = self.context.get('managed_ids', [])
-        if user is None or obj.user is None:
+        if user is None:
             return False
         if user.is_superuser:
             return True
         if obj.property.organisation.id in managed_organisations:
             return True
-        return obj.user.id == user.id
+        return obj.user.id == user.id if obj.user else False
 
     class Meta:
         model = AnnualPopulation

--- a/django_project/frontend/serializers/report.py
+++ b/django_project/frontend/serializers/report.py
@@ -46,9 +46,18 @@ class SpeciesReportSerializer(
     Serializer for Species Report.
     """
     upload_id = serializers.SerializerMethodField()
+    is_editable = serializers.SerializerMethodField()
 
     def get_upload_id(self, obj: AnnualPopulation):
         return obj.id
+
+    def get_is_editable(self, obj: AnnualPopulation):
+        user = self.context.get('user', None)
+        if user is None:
+            return False
+        if user.is_superuser:
+            return True
+        return obj.user.id == user.id if obj.user else False
 
     class Meta:
         model = AnnualPopulation
@@ -58,7 +67,8 @@ class SpeciesReportSerializer(
             "scientific_name", "common_name",
             "year", "group", "total", "adult_male", "adult_female",
             "juvenile_male", "juvenile_female", "sub_adult_male",
-            "sub_adult_female", "upload_id", "property_id"
+            "sub_adult_female", "upload_id", "property_id",
+            "is_editable"
         ]
 
 

--- a/django_project/frontend/serializers/report.py
+++ b/django_project/frontend/serializers/report.py
@@ -53,11 +53,14 @@ class SpeciesReportSerializer(
 
     def get_is_editable(self, obj: AnnualPopulation):
         user = self.context.get('user', None)
-        if user is None:
+        managed_organisations = self.context.get('managed_ids', [])
+        if user is None or obj.user is None:
             return False
         if user.is_superuser:
             return True
-        return obj.user.id == user.id if obj.user else False
+        if obj.property.organisation.id in managed_organisations:
+            return True
+        return obj.user.id == user.id
 
     class Meta:
         model = AnnualPopulation

--- a/django_project/frontend/src/containers/MainPage/Data/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Data/index.tsx
@@ -31,7 +31,7 @@ const MenuProps = {
 };
 
 const FETCH_AVAILABLE_DATA = '/api/data-table/'
-const EXCLUDED_COLUMNS = ['upload_id', 'property_id']
+const EXCLUDED_COLUMNS = ['upload_id', 'property_id', 'is_editable']
 
 const DataList = () => {
     const selectedSpecies = useAppSelector((state: RootState) => state.SpeciesFilter.selectedSpecies)
@@ -262,7 +262,7 @@ const DataList = () => {
                                         <GridActionsCellItem key={params.id} icon={<EditIcon />} onClick={() => {
                                             let _speciesReportRow = params.row as any
                                             window.location.replace(window.location.origin + `/upload-data/${_speciesReportRow.property_id}/?upload_id=${_speciesReportRow.upload_id}`)
-                                        }} label="Edit Data" title="Edit Data" />
+                                        }} label="Edit Data" title="Edit Data" hidden={!params.row.is_editable} />
                                       ]
                                 })
                             }

--- a/django_project/frontend/tests/test_online_form_view.py
+++ b/django_project/frontend/tests/test_online_form_view.py
@@ -4,6 +4,8 @@ from frontend.views.online_form import OnlineFormView
 from django.urls import reverse
 from property.factories import PropertyFactory
 from population_data.factories import AnnualPopulationF
+from frontend.tests.model_factories import UserF
+from stakeholder.factories import organisationRepresentativeFactory, organisationUserFactory
 
 
 class TestOnlineFormViewView(RegisteredBaseViewTestBase):
@@ -50,13 +52,54 @@ class TestOnlineFormViewView(RegisteredBaseViewTestBase):
 
     def test_with_upload_id(self):
         population = AnnualPopulationF.create(
-            property=self.property
+            property=self.property,
+            user=self.user_2
         )
         kwargs = {
             'property_id': self.property.id
         }
         request = self.factory.get(reverse(self.view_name, kwargs=kwargs) + f'?upload_id={population.id}')
         request.user = self.superuser
+        view = self.view_cls()
+        view.setup(request)
+        context = view.get_context_data(**kwargs)
+        self.assertIn('property_id', context)
+        self.assertEqual(context['property_id'], self.property.id)
+        self.assertIn('upload_id', context)
+        self.assertEqual(context['upload_id'], population.id)
+        # test with any user
+        user_3 = UserF.create()
+        request = self.factory.get(reverse(self.view_name, kwargs=kwargs) + f'?upload_id={population.id}')
+        request.user = user_3
+        view = self.view_cls()
+        view.setup(request)
+        with self.assertRaises(PermissionDenied):
+            context = view.get_context_data(**kwargs)
+        # test with manager
+        organisationRepresentativeFactory.create(
+            organisation=self.property.organisation,
+            user=user_3
+        )
+        organisationUserFactory.create(
+            organisation=self.property.organisation,
+            user=user_3
+        )
+        request = self.factory.get(reverse(self.view_name, kwargs=kwargs) + f'?upload_id={population.id}')
+        request.user = user_3
+        view = self.view_cls()
+        view.setup(request)
+        context = view.get_context_data(**kwargs)
+        self.assertIn('property_id', context)
+        self.assertEqual(context['property_id'], self.property.id)
+        self.assertIn('upload_id', context)
+        self.assertEqual(context['upload_id'], population.id)
+        # test with data owner
+        organisationUserFactory.create(
+            organisation=self.property.organisation,
+            user=self.user_2
+        )
+        request = self.factory.get(reverse(self.view_name, kwargs=kwargs) + f'?upload_id={population.id}')
+        request.user = self.user_2
         view = self.view_cls()
         view.setup(request)
         context = view.get_context_data(**kwargs)

--- a/django_project/frontend/tests/test_serializers.py
+++ b/django_project/frontend/tests/test_serializers.py
@@ -89,6 +89,19 @@ class TestReportSerializer(AnnualPopulationTestMixins, TestCase):
             serializer.data,
             expected_value
         )
+        # test with manager
+        serializer = SpeciesReportSerializer(
+            annual_population,
+            context={
+                'user': other_user,
+                'managed_ids': [self.organisation_1.id]
+            }
+        )
+        expected_value['is_editable'] = True
+        self.assertEqual(
+            serializer.data,
+            expected_value
+        )
 
     def test_property_report_serializer(self):
         serializer = PropertyReportSerializer(self.annual_population)

--- a/django_project/frontend/utils/data_table.py
+++ b/django_project/frontend/utils/data_table.py
@@ -201,7 +201,10 @@ def species_report(queryset: QuerySet, request) -> List:
     ).distinct()
     species_reports = SpeciesReportSerializer(
         species_population_data,
-        many=True
+        many=True,
+        context={
+            'user': request.user
+        }
     ).data
     return species_reports
 

--- a/django_project/frontend/utils/data_table.py
+++ b/django_project/frontend/utils/data_table.py
@@ -37,6 +37,7 @@ from population_data.models import (
 from property.models import Property
 from property.models import Province
 from species.models import Taxon
+from stakeholder.models import OrganisationRepresentative
 
 logger = logging.getLogger('sawps')
 
@@ -195,15 +196,22 @@ def species_report(queryset: QuerySet, request) -> List:
         request: The HTTP request object.
     """
     filters = get_report_filter(request, SPECIES_REPORT)
-    species_population_data = AnnualPopulation.objects.filter(
+    species_population_data = AnnualPopulation.objects.select_related(
+        'taxon', 'property', 'property__organisation', 'user'
+    ).filter(
         property_id__in=queryset.values_list('id', flat=True),
         **filters
     ).distinct()
+    # fetch organisations ids where user is manager
+    managed_ids = OrganisationRepresentative.objects.filter(
+        user=request.user
+    ).values_list('organisation_id', flat=True)
     species_reports = SpeciesReportSerializer(
         species_population_data,
         many=True,
         context={
-            'user': request.user
+            'user': request.user,
+            'managed_ids': managed_ids
         }
     ).data
     return species_reports

--- a/django_project/frontend/views/online_form.py
+++ b/django_project/frontend/views/online_form.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from .base_view import RegisteredOrganisationBaseView
 from property.models import Property
-from stakeholder.models import OrganisationUser
+from stakeholder.models import OrganisationUser, OrganisationRepresentative
 from population_data.models import AnnualPopulation
 
 
@@ -13,6 +13,18 @@ class OnlineFormView(RegisteredOrganisationBaseView):
     """
 
     template_name = 'online_form.html'
+
+    def validate_data_edit_access(self, upload: AnnualPopulation, user):
+        # validate if user is data owner or manager
+        if user.is_superuser:
+            return True
+        is_manager = OrganisationRepresentative.objects.filter(
+            user=user,
+            organisation=upload.property.organisation
+        ).exists()
+        if is_manager:
+            return True
+        return upload.user.id == user.id
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -37,5 +49,10 @@ class OnlineFormView(RegisteredOrganisationBaseView):
                 property_id=property_id
             ).first()
             if valid_upload:
+                if (
+                    not self.validate_data_edit_access(
+                        valid_upload, self.request.user)
+                ):
+                    raise PermissionDenied()
                 ctx['upload_id'] = valid_upload.id
         return ctx


### PR DESCRIPTION
This is for #1717.
The edit icon is now hidden when user is not the owner. cc: @LunaAsefaw 
Preview:
![image](https://github.com/kartoza/sawps/assets/5819076/554f0c93-a55c-4342-8ae0-b3cea9622c4e)

This is also for #1727 - applies to online form only. (I will submit another PR for edit from csv/excel upload)