### PR TITLE
Fix api error when property id is empty

### DIFF
--- a/django_project/frontend/api_views/statistical.py
+++ b/django_project/frontend/api_views/statistical.py
@@ -76,7 +76,9 @@ class SpeciesTrend(SpeciesNationalTrend):
 
     def get_properties_names(self):
         filter_property = self.request.data.get('property', None)
-        property_id_list = ast.literal_eval('(' + filter_property + ',)')
+        property_id_list = []
+        if filter_property:
+            property_id_list = ast.literal_eval('(' + filter_property + ',)')
         return Property.objects.filter(
             id__in=property_id_list
         ).values_list('name', flat=True).distinct()

--- a/django_project/frontend/src/containers/MainPage/Trends/PropertyTrendSection.tsx
+++ b/django_project/frontend/src/containers/MainPage/Trends/PropertyTrendSection.tsx
@@ -60,10 +60,10 @@ const PropertyTrendSection = (props: PropertyTrendSectionInterface) => {
 
 
     return (
-        <Box className={'SectionContainer'}>
+        <Box className={'SectionContainer' + (Object.keys(populationTrendData).length == 0 ? ' SectionEmpty': '')}>
             <Grid container flexDirection={'column'}>
                 <Grid item className='SectionTitle'>
-                    <Typography>Property</Typography>
+                    <Typography>{Object.keys(populationTrendData).length > 1 ? 'Properties' : 'Property'}</Typography>
                     <Divider />
                 </Grid>
                 <Grid item>

--- a/django_project/frontend/src/containers/MainPage/Trends/index.scss
+++ b/django_project/frontend/src/containers/MainPage/Trends/index.scss
@@ -35,8 +35,9 @@
       border-color: #86BC8B;
     }
   }
-
-  
+  &.SectionEmpty {
+    display: none;
+  }  
 }
 
 .PopulationTrendChartContainer {

--- a/django_project/frontend/tests/test_api_statistical.py
+++ b/django_project/frontend/tests/test_api_statistical.py
@@ -218,6 +218,20 @@ class TestAPIStatistical(TestCase):
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+        # test empty property id
+        data = {
+            'species': self.taxon.scientific_name,
+            'property': ''
+        }
+        request = self.factory.post(
+            reverse('species-population-trend'),
+            data=data, format='json'
+        )
+        request.user = self.user_1
+        view = SpeciesTrend.as_view()
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
         # remove test file
         output.delete()
 


### PR DESCRIPTION
This is for #1667.

- Section title 'Property' if single property is displayed

![Screenshot_4800](https://github.com/kartoza/sawps/assets/5819076/e3a35e8d-b08f-4a3e-a37f-e00c04582771)

- Section title 'Properties' if multiple properties are displayed

![Screenshot_4801](https://github.com/kartoza/sawps/assets/5819076/350cb08a-a362-4111-86b6-76fbdd25570b)

- Remove section if there is no property is selected
- Fix API error when no property is selected