### PR TITLE
feature/1741: Remove SpeciesCountAsPercentage from chart page

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -264,23 +264,6 @@ const Metrics = () => {
                                 </Grid>
                             )}
 
-                            {
-                            userInfoData?.user_permissions.includes('Can view province species count as percentage') &&
-                            selectedSpecies &&
-                            (
-                                <Grid item xs={12} md={12} lg={6}>
-                                    <SpeciesCountAsPercentage
-                                        selectedSpecies={selectedSpecies}
-                                        propertyId={propertyId}
-                                        startYear={startYear}
-                                        endYear={endYear}
-                                        loading={loading}
-                                        setLoading={setLoading}
-                                        activityData={activityData}
-                                    />
-                                </Grid>
-                            )}
-
 
                             {
                             constants.canViewTotalCount &&


### PR DESCRIPTION
This is PR for #1741 
![Screenshot from 2023-11-29 10-16-44](https://github.com/kartoza/sawps/assets/7352963/4786d6ee-3903-43c9-a997-d2ccdbe5ffd0)
