### PR TITLE
fix/1761: Area Comparison Chart Issue

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Metrics/AreaAvailableLineChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/AreaAvailableLineChart.tsx
@@ -78,22 +78,18 @@ const AreaAvailableLineChart = (props: any) => {
     const areaDataB: AreaDataValueB = AreaDataValue
 
       if (areaDataB.labels.length === 1) {
-        const year = areaDataB.labels[0];
-        if (!isNaN(year)) {
-          // Modify the data in place by adding the previous year to labels
-          areaDataB.labels = [year - 1, year];
-        }
+        areaDataB.labels = []
       }
 
-      useEffect(() => {
+    useEffect(() => {
         fetchAreaAvailableLineData()
-      }, [propertyId, startYear, endYear, selectedSpecies]);
+    }, [propertyId, startYear, endYear, selectedSpecies]);
 
-      areaDataB.datasets.forEach(dataset => {
+    areaDataB.datasets.forEach(dataset => {
         if (dataset.data.length === 1) {
-          dataset.data.unshift(0);
+            dataset.data = [];
         }
-      });
+    });
 
     const AreaOptions = {
         tension: 0.5,


### PR DESCRIPTION
This is PR for #1761 
When there is only 1 data, render empty chart to make it consistent with other charts.
[Kazam_screencast_00063.webm](https://github.com/kartoza/sawps/assets/7352963/3dc4980c-6070-4cb5-946b-9f65a7b25433)
