### PR TITLE
Search parcel parent farm with its subset parcels

### DIFF
--- a/django_project/frontend/models/parcels.py
+++ b/django_project/frontend/models/parcels.py
@@ -29,6 +29,11 @@ class ParcelBase(models.Model):
         db_index=True
     )
 
+    @classmethod
+    def get_table_name(cls):
+        db_table = cls._meta.db_table
+        return db_table.replace('layer"."', '')
+
     class Meta:
         """Meta class for ParcelBase."""
         abstract = True

--- a/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
+++ b/django_project/frontend/src/containers/MainPage/Map/MapUtility.ts
@@ -158,10 +158,10 @@ export const isContextLayerSelected = (contextLayers: ContextLayerInterface[], c
  * @param lngLat
  * @param callback
  */
-export const searchParcel = (lngLat: maplibregl.LngLat, propertyId: number, currentZoom: number, callback: (parcel: ParcelInterface) => void) => {
+export const searchParcel = (lngLat: maplibregl.LngLat, propertyId: number, currentZoom: number, callback: (parcels: ParcelInterface[]) => void) => {
     axios.get(SEARCH_PARCEL_URL + `?lat=${lngLat.lat}&lng=${lngLat.lng}&property_id=${propertyId}&zoom=${currentZoom}`).then((response) => {
         if (response.data) {
-            callback(response.data as ParcelInterface)
+            callback(response.data as ParcelInterface[])
         } else {
             callback(null)
         }

--- a/django_project/frontend/src/containers/MainPage/Map/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Map/index.tsx
@@ -9,7 +9,7 @@ import { debounce } from '@mui/material/utils';
 import {useAppDispatch, useAppSelector } from '../../../app/hooks';
 import {
   setMapReady,
-  toggleParcelSelectedState,
+  addParcelsAsSelected,
   setSelectedProperty,
   resetSelectedProperty,
   selectedParcelsOnRenderFinished,
@@ -478,16 +478,16 @@ export default function Map(props: MapInterface) {
   const mapOnClick = useCallback((e: any) => {
     if (contextLayers.length === 0) return;
     if (selectionMode === MapSelectionMode.None) return;
-    let _parcelLayer = findParcelLayer(contextLayers)
+    const _parcelLayer = findParcelLayer(contextLayers)
     if (typeof _parcelLayer === 'undefined') return;
     let _mapZoom = Math.trunc(map.current.getZoom())
     if (selectionMode === MapSelectionMode.Parcel) {
       // skip search if not in the parcel zoom
       if (_mapZoom < MIN_SELECT_PARCEL_ZOOM_LEVEL) return;
       // find parcel
-      searchParcel(e.lngLat, selectedProperty.id, _mapZoom, (parcel: ParcelInterface) => {
-        if (parcel) {
-          dispatch(toggleParcelSelectedState(parcel))
+      searchParcel(e.lngLat, selectedProperty.id, _mapZoom, (parcels: ParcelInterface[]) => {
+        if (parcels) {
+          dispatch(addParcelsAsSelected(parcels))
         }
       })
     } else if (selectionMode === MapSelectionMode.Property && uploadMode === UploadMode.None) {
@@ -498,7 +498,6 @@ export default function Map(props: MapInterface) {
         // skip search if not in the properties layer minZoom
         _areaSourceLayers.push('properties')
       }
-      const _parcelLayer = findParcelLayer(contextLayers)
       let _fillParcelLayers:string[] = []
       if (_mapZoom >= MIN_SEARCH_PARCEL_ZOOM_LEVEL && _parcelLayer && _parcelLayer.isSelected) {
         // need to use invisible parcel layers

--- a/django_project/frontend/src/containers/MainPage/Upload/SelectedParcelTable.tsx
+++ b/django_project/frontend/src/containers/MainPage/Upload/SelectedParcelTable.tsx
@@ -8,6 +8,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import IconButton from '@mui/material/IconButton';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import ParcelInterface from '../../../models/Parcel';
 import {capitalize} from '../../../utils/Helpers';
 
@@ -16,6 +17,7 @@ interface SelectedParcelTableInterface {
     parcels: ParcelInterface[];
     onRemoveParcel: (parcel: ParcelInterface) => void;
     onParcelHovered?: (parcel: ParcelInterface) => void;
+    onRemoveParcelByLayer: (layer_names: string[]) => void;
 }
 
 interface RowInterface {
@@ -68,7 +70,7 @@ export default function SelectedParcelTable(props: SelectedParcelTableInterface)
         <TableContainer component={Paper}>
             <Table className='PropertySiteDetailTable' aria-label="property site detail table" size='medium'>
                 <TableHead>
-                    <TableRow>
+                    <TableRow key={'table-header'}>
                         <TableCell style={{width: '60%'}}>Parcel ID</TableCell>
                         <TableCell style={{width: '30%'}}>Parcel Type</TableCell>
                         <TableCell style={{width: '10%'}}></TableCell>
@@ -76,21 +78,31 @@ export default function SelectedParcelTable(props: SelectedParcelTableInterface)
                 </TableHead>
                 <TableBody>
                     { parentFarms.length > 0 &&
-                        <TableRow>
-                            <TableCell colSpan={3} className='SelectedParcelSection'>Parent Farm</TableCell>
+                        <TableRow key={'table-parent-farm'}>
+                            <TableCell colSpan={2} className='SelectedParcelSection'>Parent Farm</TableCell>
+                            <TableCell>
+                                <IconButton aria-label='Clear all parent farms' title='Clear all parent farms' onClick={() => props.onRemoveParcelByLayer(['parent_farm'])}>
+                                    <DeleteSweepIcon />
+                                </IconButton>
+                            </TableCell>
                         </TableRow>
                     }
                     { parentFarms.length > 0 && parentFarms.map((parcel: ParcelInterface, index: number) => {
-                        return <Row index={index} parcel={parcel} onRemoveParcel={props.onRemoveParcel} onParcelHovered={props.onParcelHovered} />
+                        return <Row key={`parent-farm-${index}`} index={index} parcel={parcel} onRemoveParcel={props.onRemoveParcel} onParcelHovered={props.onParcelHovered} />
                     })
                     }
-                    { parentFarms.length > 0 && others.length > 0 &&
-                        <TableRow>
-                            <TableCell colSpan={3} className='SelectedParcelSection'>Others (Erf, Holding, Farm Portion)</TableCell>
+                    { others.length > 0 && others.length > 0 &&
+                        <TableRow key={'table-others'}>
+                            <TableCell colSpan={2} className='SelectedParcelSection'>Others (Erf, Holding, Farm Portion)</TableCell>
+                            <TableCell>
+                                <IconButton aria-label='Clear all others' title='Clear all others' onClick={() => props.onRemoveParcelByLayer(['erf', 'holding', 'farm_portion'])}>
+                                    <DeleteSweepIcon />
+                                </IconButton>
+                            </TableCell>
                         </TableRow>
                     }
                     { others.map((parcel: ParcelInterface, index: number) => {
-                        return <Row index={index} parcel={parcel} onRemoveParcel={props.onRemoveParcel} onParcelHovered={props.onParcelHovered} />
+                        return <Row key={`others-${index}`} index={index} parcel={parcel} onRemoveParcel={props.onRemoveParcel} onParcelHovered={props.onParcelHovered} />
                     })
                     }
                 </TableBody>

--- a/django_project/frontend/src/containers/MainPage/Upload/Step2.tsx
+++ b/django_project/frontend/src/containers/MainPage/Upload/Step2.tsx
@@ -10,7 +10,8 @@ import {
     toggleParcelSelectionMode,
     toggleParcelSelectedState,
     triggerMapEvent,
-    toggleDigitiseSelectionMode
+    toggleDigitiseSelectionMode,
+    clearSelectedParcelByLayer
 } from '../../../reducers/MapState';
 import {RootState} from '../../../app/store';
 import {postData} from "../../../utils/Requests";
@@ -115,6 +116,9 @@ export default function Step2(props: Step2Interface) {
                                         'payload': []
                                     }))
                                 }
+                            }}
+                            onRemoveParcelByLayer={(layer_names: string[]) => {
+                                dispatch(clearSelectedParcelByLayer(layer_names))
                             }}
                         />
                     </Grid>

--- a/django_project/frontend/src/containers/MainPage/Upload/UploadWizard.tsx
+++ b/django_project/frontend/src/containers/MainPage/Upload/UploadWizard.tsx
@@ -40,7 +40,7 @@ export default function UploadWizard(props: UploadWizardInterface) {
                 >
                         <Tab key={0} label={'STEP 1'} {...a11yProps(0)} sx={{flex:1}} />
                         <Tab key={1} label={'STEP 2'} {...a11yProps(1)} disabled={!isPropertyInfoValid} sx={{flex:1}} />
-                        <Tab key={2} label={'STEP 3'} {...a11yProps(2)} disabled={property.id===0} sx={{flex:1}} />
+                        <Tab key={2} label={'SUMMARY'} {...a11yProps(2)} disabled={property.id===0} sx={{flex:1}} />
                 </Tabs>
             </Box>
             <Box className='TabPanels FlexContainerFill'>


### PR DESCRIPTION
This is for #1766 

TODO:

- [ ] Disable map and add loading indicator when selecting parent farms or clear all parcels. Currently, a selection to 1 parent farm can have thousands of smaller parcels being selected too, this makes the UI for rendering the table+map stuck for like 2-3seconds.
- [ ] Add logic to select smaller parcels from parent farm to shapefile upload process
- [ ] Add tests
- [ ] we may also need to make create property as background job (I checked with 1500parcels, it took 20s to process)