### PR TITLE
reset start year filter when navigate from reports tab

### DIFF
--- a/django_project/frontend/src/components/PdfReport/PopulationCategoryChart.tsx
+++ b/django_project/frontend/src/components/PdfReport/PopulationCategoryChart.tsx
@@ -6,6 +6,7 @@ import Chart from "chart.js/auto";
 import ChartDataLabels from "chartjs-plugin-datalabels";
 import axios from "axios";
 import Loading from "../Loading";
+import { DEFAULT_START_YEAR_FILTER, DEFAULT_END_YEAR_FILTER } from "../../reducers/SpeciesFilter";
 
 Chart.register(CategoryScale);
 Chart.register(ChartDataLabels);
@@ -46,8 +47,8 @@ const PopulationCategoryChart = () => {
     }, []);
 
     const fetchPopulationCategoryData = (selectedSpecies: string[]) => {
-        const startYear = 1960;
-        const endYear = new Date().getFullYear();
+        const startYear = DEFAULT_START_YEAR_FILTER;
+        const endYear = DEFAULT_END_YEAR_FILTER;
         const fetchDataPromises = selectedSpecies.map((speciesName) => {
             return axios.get(`${FETCH_SPECIES_DENSITY}?start_year=${startYear}&end_year=${endYear}&species=${speciesName}`)
                 .then((response) => {

--- a/django_project/frontend/src/containers/MainPage/MainPage.tsx
+++ b/django_project/frontend/src/containers/MainPage/MainPage.tsx
@@ -22,6 +22,7 @@ import DataList from './Data';
 import Metrics from './Metrics';
 import Trends from './Trends';
 import { HelperContainerWithToggle } from "../../components/HelperContainer";
+import { setStartYear, DEFAULT_START_YEAR_FILTER } from '../../reducers/SpeciesFilter';
 
 const tabNames = ['map', 'reports', 'charts', 'trends', 'upload'];
 
@@ -161,6 +162,10 @@ function MainPage() {
                       value={selectedTab}
                       onChange={(event: React.SyntheticEvent, newValue: number) => {
                         const tabNames = ['map', 'reports', 'charts', 'trends', 'upload'];
+                        // if navigated from reports tab, then reset the startYear value back to DEFAULT_START_YEAR_FILTER
+                        if (selectedTab === 1 && newValue !== 1) {
+                          dispatch(setStartYear(DEFAULT_START_YEAR_FILTER))
+                        }
                         const selectedTabName = tabNames[newValue];
                         setSelectedTab(newValue);
                         if (selectedTabName === 'upload') {

--- a/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
+++ b/django_project/frontend/src/containers/MainPage/SideBar/Filter.tsx
@@ -28,7 +28,8 @@ import {
     toggleSpecies,
     toggleSpeciesList,
     setSelectedProvinceName,
-    setSelectedProvinceCount
+    DEFAULT_START_YEAR_FILTER,
+    DEFAULT_END_YEAR_FILTER
 } from '../../../reducers/SpeciesFilter';
 import './index.scss';
 import {MapEvents} from '../../../models/Map';
@@ -52,8 +53,8 @@ import {AutoCompleteCheckbox} from "../../../components/SideBar/index";
 import {SeachPlaceResult} from '../../../utils/SearchPlaces';
 import SearchPlace from '../../../components/SearchPlace';
 
-const yearRangeStart = 1960;
-const yearRangeEnd = new Date().getFullYear();
+const yearRangeStart = DEFAULT_START_YEAR_FILTER;
+const yearRangeEnd = DEFAULT_END_YEAR_FILTER;
 const FETCH_PROPERTY_DETAIL_URL = '/api/property/detail/'
 
 function Filter(props: any) {
@@ -231,6 +232,10 @@ function Filter(props: any) {
     const handleSelectedSpecies = (value: string) => {
         setSelectedSpecies(value);
     };
+
+    useEffect(() => {
+        setLocalStartYear(startYear)
+    }, [startYear])
 
     useEffect(() => {
         if (selectedSpeciesList.length === 0 && selectedSpecies !== "") {

--- a/django_project/frontend/src/containers/MainPage/Trends/NationalTrendSection.tsx
+++ b/django_project/frontend/src/containers/MainPage/Trends/NationalTrendSection.tsx
@@ -8,6 +8,7 @@ import './index.scss';
 import Loading from '../../../components/Loading';
 import AreaAvailableLineChart from "../Metrics/AreaAvailableLineChart";
 import { capitalizeSentence } from '../../../utils/Helpers';
+import { DEFAULT_START_YEAR_FILTER, DEFAULT_END_YEAR_FILTER } from '../../../reducers/SpeciesFilter';
 
 
 interface NationalTrendSectionInterface {
@@ -110,8 +111,8 @@ const NationalTrendSection = (props: NationalTrendSectionInterface) => {
                                 <Grid item style={{ marginTop: 15 }}>
                                     <AreaAvailableLineChart
                                         propertyId={''}
-                                        startYear={1960}
-                                        endYear={new Date().getFullYear()}
+                                        startYear={DEFAULT_START_YEAR_FILTER}
+                                        endYear={DEFAULT_END_YEAR_FILTER}
                                         national={true}
                                     />
                                 </Grid>

--- a/django_project/frontend/src/reducers/SpeciesFilter.ts
+++ b/django_project/frontend/src/reducers/SpeciesFilter.ts
@@ -24,14 +24,17 @@ export interface SpeciesFilterInterface {
   selectedProvinceCount: number,
 }
 
+export const DEFAULT_START_YEAR_FILTER = 1960
+export const DEFAULT_END_YEAR_FILTER = new Date().getFullYear()
+
 const initialState: SpeciesFilterInterface = {
   SpeciesFilterList: [],
   selectedSpecies: "",
   selectedSpeciesList: "",
   months: [],
   selectedMonths: "",
-  startYear: 1960,
-  endYear:new Date().getFullYear(),
+  startYear: DEFAULT_START_YEAR_FILTER,
+  endYear:DEFAULT_END_YEAR_FILTER,
   propertyId:"",
   selectedInfoList:"",
   organisationId:"",


### PR DESCRIPTION
This is for #1818.
Preview:
![chrome_xWpov5I3U7](https://github.com/kartoza/sawps/assets/5819076/b9a09ca0-8625-411d-b4ad-56a6c292659d)
