### PR TITLE
add distinct for sum population data

### DIFF
--- a/django_project/frontend/utils/metrics.py
+++ b/django_project/frontend/utils/metrics.py
@@ -23,7 +23,7 @@ def calculate_species_count_per_province(
     ).values(
         'year', 'property__province__name', 'taxon__scientific_name'
     ).annotate(
-        total_population=Sum('total')
+        total_population=Sum('total', distinct=True)
     ).order_by('-year', '-total_population')
     result_data = list()
     for pop_data in annual_populations:


### PR DESCRIPTION
Issue: When there is a population data in a year having two activities data, the count in the province becomes double with all selected activities in the filter.
![oKT81aqByh](https://github.com/kartoza/sawps/assets/5819076/fe5ddd7f-a5a8-416f-8912-9312fa5916c5)

![0wP4TLFlEK](https://github.com/kartoza/sawps/assets/5819076/9ef50f9e-7d11-481d-a27e-e37ce51cadd3)

To fix this issue, I apply distinct to the sum aggregate function so it won't sum the same population record twice.