### PR TITLE
Fix trends chart x and y labels

### DIFF
--- a/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/SpeciesChart/index.tsx
+++ b/django_project/frontend/src/components/LandingPage/LandingPagePopulationOverview/SpeciesChart/index.tsx
@@ -112,6 +112,7 @@ const SpeciesChart:FC<ISpeciesChartProps> = (props)=>{
         aspectRatio: 1.5,
         scales: {
             y: {
+                beginAtZero: true,
                 grace:50,
                 ticks: {
                     color: "#fff"
@@ -119,7 +120,9 @@ const SpeciesChart:FC<ISpeciesChartProps> = (props)=>{
             },
             x: {
                 ticks: {
-                    color: "#fff"
+                    color: "#fff",
+                    maxRotation: 45,
+                    minRotation: 45
                 }
             }
         },

--- a/django_project/frontend/src/containers/MainPage/Trends/PopulationTrendChart.tsx
+++ b/django_project/frontend/src/containers/MainPage/Trends/PopulationTrendChart.tsx
@@ -85,6 +85,7 @@ const PopulationTrendChart = (props: PopulationTrendChartInterface) => {
         maintainAspectRatio: false,
         scales: {
             y: {
+              beginAtZero: true,
               grace:50,
               title: {
                 display: true,
@@ -103,6 +104,10 @@ const PopulationTrendChart = (props: PopulationTrendChartInterface) => {
                   size: 14,
                 },
               },
+              ticks: {
+                maxRotation: 45,
+                minRotation: 45
+              }
             },
         },
         plugins: {


### PR DESCRIPTION
This is for #1670.

Changes:

- Starts y axis at zero (no need to do this from R code)
- Set rotation to x labels to 45 degrees

Previews:
![Screenshot_4824](https://github.com/kartoza/sawps/assets/5819076/f6ebca40-f907-4199-99ce-7322c1d82c3a)
![Screenshot_4825](https://github.com/kartoza/sawps/assets/5819076/90e618f6-a872-4555-977b-c44a206bae18)
![Screenshot_4826](https://github.com/kartoza/sawps/assets/5819076/d8ad7af9-316b-458d-a49f-c9a48ed419ca)
