### PR TITLE
show message password changed from allauth view

### DIFF
--- a/django_project/frontend/templates/base.html
+++ b/django_project/frontend/templates/base.html
@@ -32,7 +32,7 @@
   {% block header %}
     {% include 'navibar.html' %}
     {% for message in messages %}
-    {% if 'notification' in message.tags %}
+    {% if 'notification' in message.tags or message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS and 'Password successfully changed' in message.message %}
       <div class="alert alert-success position-fixed top-0 end-0 padding" role="alert">
         {{ message }}
       </div>


### PR DESCRIPTION
This is for #1883.
Preview:
![Screenshot_4840](https://github.com/kartoza/sawps/assets/5819076/4e27fac5-b88e-422c-af86-cc94675c7ed8)


@dimasciput, this is a workaround because there should be a message from allauth changed password view. But, we only display message with tag 'notification' only. Do you know why we do that? 
Perhaps, the better approach is to override allauth change password view (like logout view in PR #1909) and send message with notification tag.