### PR TITLE
Feat enable edit year

### DIFF
--- a/django_project/frontend/api_views/population.py
+++ b/django_project/frontend/api_views/population.py
@@ -128,7 +128,7 @@ class CanWritePopulationData(APIView):
                            property: Property, taxon: Taxon):
         """Check if user is able to overwrite annual_population record."""
         user = self.request.user
-        annual_population_id = self.request.data.get('id', 0)
+        annual_population_id = int(self.request.data.get('id', 0))
         if (
             annual_population_id > 0 and
             not annual_population.is_editable(user)
@@ -159,7 +159,7 @@ class CanWritePopulationData(APIView):
         return True, None, None
 
     def find_existing_annual_population(self, taxon, property):
-        annual_population_id = self.request.data.get('id', 0)
+        annual_population_id = int(self.request.data.get('id', 0))
         annual_population = None
         if annual_population_id == 0:
             annual_population = AnnualPopulation.objects.filter(

--- a/django_project/frontend/api_views/population.py
+++ b/django_project/frontend/api_views/population.py
@@ -128,9 +128,12 @@ class CanWritePopulationData(APIView):
                            property: Property, taxon: Taxon):
         """Check if user is able to overwrite annual_population record."""
         user = self.request.user
-        if not annual_population.is_editable(user):
-            return False, self.EDIT_DATA_NO_PERMISSION_MESSAGE, None
         annual_population_id = self.request.data.get('id', 0)
+        if (
+            annual_population_id > 0 and
+            not annual_population.is_editable(user)
+        ):
+            return False, self.EDIT_DATA_NO_PERMISSION_MESSAGE, None
         year = self.request.data.get("year")
         other = None
         if annual_population_id == 0:

--- a/django_project/frontend/serializers/report.py
+++ b/django_project/frontend/serializers/report.py
@@ -70,13 +70,7 @@ class SpeciesReportSerializer(BaseSpeciesReportSerializer):
     def get_is_editable(self, obj: AnnualPopulation):
         user = self.context.get('user', None)
         managed_organisations = self.context.get('managed_ids', [])
-        if user is None:
-            return False
-        if user.is_superuser:
-            return True
-        if obj.property.organisation.id in managed_organisations:
-            return True
-        return obj.user.id == user.id if obj.user else False
+        return obj.is_editable(user, managed_organisations)
 
     class Meta:
         model = AnnualPopulation

--- a/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
+++ b/django_project/frontend/src/containers/OnlineFormPage/Forms/SpeciesDetail.tsx
@@ -357,7 +357,6 @@ export default function SpeciesDetail(props: SpeciesDetailInterface) {
                                                 value={moment({'year': data.year})}
                                                 onChange={(newValue: Moment) => updateYearDetail(newValue.year())}
                                                 maxDate={moment({'year': new Date().getFullYear()})}
-                                                disabled={isEdit}
                                             />
                                             <FormHelperText>{' '}</FormHelperText>
                                         </LocalizationProvider>

--- a/django_project/frontend/src/models/Upload.ts
+++ b/django_project/frontend/src/models/Upload.ts
@@ -55,6 +55,7 @@ export interface AnnualPopulationPerActivityInterface {
 }
 
 export interface UploadSpeciesDetailInterface {
+    id?: number;
     taxon_id: number;
     taxon_name?: string;
     common_name?: string;
@@ -64,6 +65,7 @@ export interface UploadSpeciesDetailInterface {
     annual_population: AnnualPopulationInterface;
     intake_populations: AnnualPopulationPerActivityInterface[];
     offtake_populations: AnnualPopulationPerActivityInterface[];
+    confirm_overwrite?: boolean;
 }
 
 export interface TaxonMetadata {
@@ -215,6 +217,7 @@ export const getDefaultUploadSpeciesDetail = (propertyId: number, initialData?: 
             annual_population: copyAnnualPopulation(initialData.annual_population),
             intake_populations: copyActivityPopulation(initialData.intake_populations),
             offtake_populations: copyActivityPopulation(initialData.offtake_populations),
+            id: initialData.id
         }
         return _cpData
     }
@@ -227,7 +230,8 @@ export const getDefaultUploadSpeciesDetail = (propertyId: number, initialData?: 
         property_id: propertyId,
         annual_population: getDefaultAnnualPopulation(),
         intake_populations: [],
-        offtake_populations: []
+        offtake_populations: [],
+        id: 0
     }
 }
 

--- a/django_project/frontend/urls.py
+++ b/django_project/frontend/urls.py
@@ -57,7 +57,8 @@ from frontend.api_views.population import (
     PopulationMeanSDChartApiView,
     PopulationMetadataList,
     UploadPopulationAPIVIew,
-    FetchPopulationData
+    FetchPopulationData,
+    CanWritePopulationData
 )
 from frontend.api_views.property import (
     CreateNewProperty,
@@ -249,6 +250,11 @@ urlpatterns = [
         r'^api/upload/population/fetch/(?P<id>\d+)/?$',
         FetchPopulationData.as_view(),
         name='fetch-population-data'
+    ),
+    re_path(
+        r'^api/upload/population/(?P<property_id>\d+)/check/?$',
+        CanWritePopulationData.as_view(),
+        name='can-upload-population-data'
     ),
     re_path(
         r'^api/upload/population/(?P<property_id>\d+)/?$',

--- a/django_project/population_data/models.py
+++ b/django_project/population_data/models.py
@@ -154,14 +154,14 @@ class AnnualPopulation(AnnualPopulationAbstract):
         super().clean()
 
     def is_editable(self, user: User, managed_organisations = None):
-        if managed_organisations is None:
-            managed_organisations = OrganisationRepresentative.objects.filter(
-                user=user
-            ).values_list('organisation_id', flat=True)
         if user is None:
             return False
         if user.is_superuser:
             return True
+        if managed_organisations is None:
+            managed_organisations = OrganisationRepresentative.objects.filter(
+                user=user
+            ).values_list('organisation_id', flat=True)
         if self.property.organisation.id in managed_organisations:
             return True
         return self.user.id == user.id if self.user else False

--- a/django_project/population_data/models.py
+++ b/django_project/population_data/models.py
@@ -3,6 +3,7 @@
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import models
 from django.contrib.auth.models import User
+from stakeholder.models import OrganisationRepresentative
 
 
 TOTAL_POPULATION_ERROR_MESSAGE = (
@@ -151,6 +152,19 @@ class AnnualPopulation(AnnualPopulationAbstract):
                 })
 
         super().clean()
+
+    def is_editable(self, user: User, managed_organisations = None):
+        if managed_organisations is None:
+            managed_organisations = OrganisationRepresentative.objects.filter(
+                user=user
+            ).values_list('organisation_id', flat=True)
+        if user is None:
+            return False
+        if user.is_superuser:
+            return True
+        if self.property.organisation.id in managed_organisations:
+            return True
+        return self.user.id == user.id if self.user else False
 
     class Meta:
         verbose_name = "Annual Population"

--- a/django_project/species/scripts/data_upload.py
+++ b/django_project/species/scripts/data_upload.py
@@ -518,10 +518,7 @@ class SpeciesCSVUpload(object):
             ).first()
             if existing_data:
                 # validate if user can update the data: uploader or manager
-                if (
-                    not is_organisation_manager and
-                    existing_data.user.id != self.upload_session.uploader.id
-                ):
+                if existing_data.is_editable(self.upload_session.uploader):
                     self.error_row(
                         message="You are not allowed to update data of "
                                 "property {} and species {} in year {}".format(

--- a/django_project/species/scripts/data_upload.py
+++ b/django_project/species/scripts/data_upload.py
@@ -518,7 +518,10 @@ class SpeciesCSVUpload(object):
             ).first()
             if existing_data:
                 # validate if user can update the data: uploader or manager
-                if existing_data.is_editable(self.upload_session.uploader):
+                if (
+                    not existing_data.is_editable(
+                        self.upload_session.uploader)
+                ):
                     self.error_row(
                         message="You are not allowed to update data of "
                                 "property {} and species {} in year {}".format(


### PR DESCRIPTION
This is for #1946.
Preview:
![image](https://github.com/kartoza/sawps/assets/5819076/eec92023-fa05-43e9-af67-0623857e9cb4)

Logic:

- When adding new data, check and show confirmation if there is existing data for that year
- When editing existing data and change the year, check and show confirmation if there is existing data for that year