### PR TITLE
exclude overlaps less than or equal to 1sqm

### DIFF
--- a/django_project/property/tasks/check_overlaps.py
+++ b/django_project/property/tasks/check_overlaps.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class OverlapItem(object):
+    OVERLAP_AREA_THRESHOLD_IN_SQM = 1
 
     def __init__(self, property_id, other_id, intersect_geom) -> None:
         self.property_id = property_id
@@ -22,6 +23,9 @@ class OverlapItem(object):
         else:
             self.intersect_geom = intersect_geom
         self.overlap_area_size = area(intersect_geom.geojson)
+
+    def check_for_overlap_size(self):
+        return self.overlap_area_size > self.OVERLAP_AREA_THRESHOLD_IN_SQM
 
     def get_queryset(self):
         return PropertyOverlaps.objects.filter(
@@ -84,7 +88,9 @@ def check_overlaps_in_properties() -> List[OverlapItem]:
         rows = cursor.fetchall()
         for row in rows:
             geom = GEOSGeometry(row[2])
-            results.append(OverlapItem(row[0], row[1], geom))
+            item = OverlapItem(row[0], row[1], geom)
+            if item.check_for_overlap_size():
+                results.append(item)
     return results
 
 

--- a/django_project/property/tests/test_check_overlaps.py
+++ b/django_project/property/tests/test_check_overlaps.py
@@ -225,3 +225,27 @@ class TestCheckOverlaps(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mocked_task.assert_called_once()
+
+    @mock.patch('property.tasks.check_overlaps.area')
+    def test_check_overlaps_ignored(self, mocked_area):
+        mocked_area.return_value = 0.001
+        # case: overlaps
+        geom_path = absolute_path(
+            'property', 'tests',
+            'geojson', 'geom_overlaps.geojson')
+        self.load_test_geom_to_properties(geom_path)
+        results = check_overlaps_in_properties()
+        mocked_area.assert_called_once()
+        self.assertEqual(len(results), 0)
+        # should return 0
+        mocked_area.reset_mock()
+        mocked_area.return_value = 1
+        results = check_overlaps_in_properties()
+        mocked_area.assert_called_once()
+        self.assertEqual(len(results), 0)
+        # should return 1
+        mocked_area.reset_mock()
+        mocked_area.return_value = 1.5
+        results = check_overlaps_in_properties()
+        mocked_area.assert_called_once()
+        self.assertEqual(len(results), 1)


### PR DESCRIPTION
This is for #1922. Ignore overlaps with area less than or equal to 1 sqm