### PR TITLE
Hide other layer when NGI layer is selected

### DIFF
--- a/django_project/frontend/src/models/ContextLayer.ts
+++ b/django_project/frontend/src/models/ContextLayer.ts
@@ -18,3 +18,6 @@ export interface ContextLayerVisibilityPayload {
     isVisible: boolean;
 }
 
+
+export const NGI_AERIAL_IMAGERY_LAYER = 'NGI Aerial Imagery'
+export const NGI_LAYER_GROUP = ['Properties', NGI_AERIAL_IMAGERY_LAYER]

--- a/django_project/frontend/src/reducers/LayerFilter.ts
+++ b/django_project/frontend/src/reducers/LayerFilter.ts
@@ -1,5 +1,5 @@
 import {createSlice, PayloadAction} from "@reduxjs/toolkit";
-import ContextLayerInterface, {ContextLayerVisibilityPayload} from '../models/ContextLayer';
+import ContextLayerInterface, {ContextLayerVisibilityPayload, NGI_AERIAL_IMAGERY_LAYER, NGI_LAYER_GROUP} from '../models/ContextLayer';
 
 export interface LayerFilterInterface {
     contextLayers: ContextLayerInterface[];
@@ -28,10 +28,35 @@ export const LayerFilterSlice = createSlice({
             state.contextLayers = [..._layers]
         },
         toggleLayer: (state, action: PayloadAction<number>) => {
+            let _payloadLayers = state.contextLayers.filter(a => a.id === action.payload)
+            let _foundLayer: ContextLayerInterface = null;
+            if (_payloadLayers.length) {
+                _foundLayer = {..._payloadLayers[0]}
+            }
+            console.log('foundLayer : ', _foundLayer)
             let _layers = state.contextLayers.map((layer) => {
-                if (action.payload === layer.id) {
-                    layer.isSelected = !layer.isSelected
+                if (_foundLayer && _foundLayer.name === NGI_AERIAL_IMAGERY_LAYER) {
+                    if (!_foundLayer.isSelected) {
+                        // enable NGI Aerial Image and Properties
+                        if (NGI_LAYER_GROUP.includes(layer.name)) {
+                            layer.isSelected = true
+                        } else {
+                            layer.isSelected = false
+                        }
+                    } else {
+                        // disable NGI Aerial Image and enable the rest
+                        if (layer.name === NGI_AERIAL_IMAGERY_LAYER) {
+                            layer.isSelected = false
+                        } else {
+                            layer.isSelected = true
+                        }
+                    }                    
+                } else {
+                    if (action.payload === layer.id) {
+                        layer.isSelected = !layer.isSelected
+                    }
                 }
+                console.log('layer name: ', layer.name, layer.isSelected)
                 return layer
             })
             state.contextLayers = [..._layers]

--- a/django_project/frontend/src/reducers/LayerFilter.ts
+++ b/django_project/frontend/src/reducers/LayerFilter.ts
@@ -33,7 +33,6 @@ export const LayerFilterSlice = createSlice({
             if (_payloadLayers.length) {
                 _foundLayer = {..._payloadLayers[0]}
             }
-            console.log('foundLayer : ', _foundLayer)
             let _layers = state.contextLayers.map((layer) => {
                 if (_foundLayer && _foundLayer.name === NGI_AERIAL_IMAGERY_LAYER) {
                     if (!_foundLayer.isSelected) {


### PR DESCRIPTION
This is for #2022.
Preview:
![Peek 2024-03-06 10-01](https://github.com/kartoza/sawps/assets/5819076/7298b8a4-54b4-44de-a62c-10d5051c8e04)

Also add cache-control header to the NGI layer API.