### PR TITLE
fix numpy dependency error

### DIFF
--- a/deployment/docker/requirements.txt
+++ b/deployment/docker/requirements.txt
@@ -59,6 +59,8 @@ django-easy-audit==1.3.5
 # for reading excel file
 pandas==2.1.0
 openpyxl==3.1.2
+# fix pandas dependency from numpy
+numpy==1.26.4
 
 # For documentation frontend
 -e git+https://github.com/kartoza/django-docs-crawler.git@1.1.0#egg=django-docs-crawler


### PR DESCRIPTION
This is to fix below error:
```
File "/home/web/django_project/frontend/utils/data_table.py", line 9, in <module>
    import pandas as pd
  File "/usr/local/lib/python3.10/site-packages/pandas/__init__.py", line 46, in <module>
    from pandas.core.api import (
  File "/usr/local/lib/python3.10/site-packages/pandas/core/api.py", line 1, in <module>
    from pandas._libs import (
  File "/usr/local/lib/python3.10/site-packages/pandas/_libs/__init__.py", line 18, in <module>
    from pandas._libs.interval import Interval
  File "interval.pyx", line 1, in init pandas._libs.interval
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```