### PR TITLE
fix export pdf on metrics

### DIFF
--- a/django_project/frontend/src/containers/MainPage/Data/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Data/index.tsx
@@ -354,7 +354,7 @@ const DataList = () => {
         const activityDataGrid = isDataConsumer(userInfoData) && activityDataSet.length > 0 ?
           null : activityDataSet.map((each: any) =>
             <Box key={each}>
-                <Box className="data-table"
+                <Box className="data-table data-grid data-table-header"
                      style={{
                          backgroundColor: (customColorWidth as any)[each]?.color,
                          marginTop: '20px',

--- a/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
+++ b/django_project/frontend/src/containers/MainPage/Metrics/index.tsx
@@ -102,11 +102,11 @@ const Metrics = () => {
           heightLeft -= pageHeight;
           const doc = new jsPDF('p', 'mm');
           doc.setFillColor('245');
-          doc.addImage(canvas, 'PNG', 0, position, imgWidth, imgHeight, '', 'FAST');
+          doc.addImage(canvas, 'PNG', 0, position, imgWidth, imgHeight + 30, '', 'FAST');
           while (heightLeft >= 0) {
             position = heightLeft - imgHeight;
             doc.addPage();
-            doc.addImage(canvas, 'PNG', 0, position, imgWidth, imgHeight, '', 'FAST');
+            doc.addImage(canvas, 'PNG', 0, position, imgWidth, imgHeight + 30, '', 'FAST');
             heightLeft -= pageHeight;
           }
           setOpen(false)


### PR DESCRIPTION
This is for #2078. A naive fix that adds margin height in the canvas.
Generated pdf:
[Acinonyx jubatus jubatus - metrics (2).pdf](https://github.com/user-attachments/files/16406034/Acinonyx.jubatus.jubatus.-.metrics.2.pdf)

This fix will not work in data tab because the page is not fixed to 2. I've been trying another lib: https://ekoopmans.github.io/html2pdf.js/ that can support a page break. But the result is not that good either.
Data PDF using current implementation: [Acinonyx jubatus jubatus,Loxodonta africana - reports.pdf](https://github.com/user-attachments/files/16406058/Acinonyx.jubatus.jubatus.Loxodonta.africana.-.reports.pdf).

- Text in row may be splitted
- Cannot control the page break

Data PDF using html2pdf.js: [mydata.pdf](https://github.com/user-attachments/files/16406057/mydata.pdf).

- Random row height becomes higher
- Text in row is not splitted but row height is smaller.
- Spacing when using page break is not correct.
